### PR TITLE
Fix redundant call in backend install

### DIFF
--- a/gui_pyside6/backend/__init__.py
+++ b/gui_pyside6/backend/__init__.py
@@ -35,4 +35,3 @@ def ensure_backend_installed(name: str) -> None:
     missing = [pkg for pkg in packages if importlib.util.find_spec(pkg) is None]
     if missing:
         install_package_in_venv(missing)
-        install_package_in_venv(missing)


### PR DESCRIPTION
## Summary
- remove duplicate call to install_package_in_venv

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684012d454e083299b50bd5886bee20e