### PR TITLE
Add output folder button

### DIFF
--- a/gui_pyside6/SALVAGE_LOG.md
+++ b/gui_pyside6/SALVAGE_LOG.md
@@ -21,3 +21,5 @@ This file tracks files copied or cleaned during the migration to the PySide6 GUI
 - Added standalone `requirements.in` and `requirements.lock.txt` so the GUI is independent of WebUI requirements.
 - Pruned unused `extension_*` packages from `requirements.in` and regenerated the lock file.
 - Added standalone `requirements.in` and `requirements.lock.txt` so the GUI is independent of WebUI requirements.
+- Added an `Open Output Folder` button in the PySide6 UI to open the directory of
+  the most recent synthesis result.

--- a/gui_pyside6/planning.md
+++ b/gui_pyside6/planning.md
@@ -13,6 +13,9 @@ This document tracks the initial tasks for building the PySide6 Hybrid TTS appli
 - Created `run_pyside.sh` and `run_pyside.bat` to launch the new GUI.
 - Added dedicated `requirements.in` and `requirements.lock.txt` for the PySide6 GUI.
 - Pruned extension packages from requirements and documented PySide6 launcher in README.
- - **Core requirements remain minimal.** `requirements.uv.toml` lists only the base
+- **Core requirements remain minimal.** `requirements.uv.toml` lists only the base
    dependencies (PySide6, FastAPI, PyTorch, etc.). Optional TTS extensions are
    specified in `backend_requirements.json` and installed on demand at runtime.
+- Implemented an "Open Output Folder" button in the main window that opens the
+  directory of the last synthesized file and uses the existing `open_folder`
+  utility.


### PR DESCRIPTION
## Summary
- show output folder button in PySide6 main window
- save syntheses with a dated filename under `outputs/`
- document new feature in `planning.md` and `SALVAGE_LOG.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684036b7d53c832987732666ec049005