### PR TITLE
Add on-demand backend installation

### DIFF
--- a/gui_pyside6/SALVAGE_LOG.md
+++ b/gui_pyside6/SALVAGE_LOG.md
@@ -21,3 +21,18 @@ This file tracks files copied or cleaned during the migration to the PySide6 GUI
 - Added standalone `requirements.in` and `requirements.lock.txt` so the GUI is independent of WebUI requirements.
 - Pruned unused `extension_*` packages from `requirements.in` and regenerated the lock file.
 - Added standalone `requirements.in` and `requirements.lock.txt` so the GUI is independent of WebUI requirements.
+- Added an `Open Output Folder` button in the PySide6 UI to open the directory of
+  the most recent synthesis result.
+- Added a `Play Last Output` button using QtMultimedia so users can listen to
+  the generated audio without leaving the app.
+- Implemented a speech rate selector in the PySide6 UI and added an optional
+  `rate` parameter to the `pyttsx_backend` so users can control synthesis speed.
+- Added a voice selector dropdown that lists available pyttsx3 voices. The
+  selected voice is passed through to the backend and the API server now accepts
+  optional `rate` and `voice` parameters.
+- Added a basic gTTS backend with lazy installation. MP3 files are generated
+  when this backend is selected.
+- Extended gTTS backend to support a language parameter and added a language
+  selector in the GUI that becomes active when gTTS is chosen.
+- Added an "Install Backend" button that checks for missing packages and
+  installs them on demand.

--- a/gui_pyside6/backend/__init__.py
+++ b/gui_pyside6/backend/__init__.py
@@ -6,9 +6,11 @@ from pathlib import Path
 
 from ..utils.install_utils import install_package_in_venv
 from .pyttsx_backend import synthesize_to_file
+from .gtts_backend import synthesize_to_file as gtts_synthesize
 
 BACKENDS = {
     "pyttsx3": synthesize_to_file,
+    "gtts": gtts_synthesize,
 }
 
 
@@ -16,21 +18,28 @@ def available_backends():
     return list(BACKENDS.keys())
 
 
+
 _REQ_FILE = Path(__file__).with_name("backend_requirements.json")
+
+
+def _get_backend_packages(name: str) -> list[str]:
+    if not _REQ_FILE.exists():
+        return []
+    with _REQ_FILE.open() as f:
+        reqs: dict[str, list[str]] = json.load(f)
+    return reqs.get(name, [])
+
+
+def missing_backend_packages(name: str) -> list[str]:
+    return [pkg for pkg in _get_backend_packages(name) if importlib.util.find_spec(pkg) is None]
+
+
+def is_backend_installed(name: str) -> bool:
+    return not missing_backend_packages(name)
 
 
 def ensure_backend_installed(name: str) -> None:
     """Install packages required for the given backend if missing."""
-    if not _REQ_FILE.exists():
-        return
-
-    with _REQ_FILE.open() as f:
-        reqs: dict[str, list[str]] = json.load(f)
-
-    packages = reqs.get(name)
-    if not packages:
-        return
-
-    missing = [pkg for pkg in packages if importlib.util.find_spec(pkg) is None]
+    missing = missing_backend_packages(name)
     if missing:
         install_package_in_venv(missing)

--- a/gui_pyside6/backend/api_server.py
+++ b/gui_pyside6/backend/api_server.py
@@ -14,6 +14,9 @@ app = FastAPI(title="Hybrid TTS API")
 class SynthesisRequest(BaseModel):
     text: str
     backend: str = "pyttsx3"
+    rate: Optional[int] = None
+    voice: Optional[str] = None
+    lang: Optional[str] = None
 
 
 @app.post("/synthesize")
@@ -21,7 +24,9 @@ def synthesize(req: SynthesisRequest):
     if req.backend not in BACKENDS:
         raise HTTPException(status_code=400, detail="Unknown backend")
     output = Path("output_api.wav")
-    BACKENDS[req.backend](req.text, output)
+    BACKENDS[req.backend](
+        req.text, output, rate=req.rate, voice=req.voice, lang=req.lang
+    )
     return {"output": str(output)}
 
 

--- a/gui_pyside6/backend/backend_requirements.json
+++ b/gui_pyside6/backend/backend_requirements.json
@@ -1,5 +1,6 @@
 {
   "pyttsx3": ["pyttsx3"],
+  "gtts": ["gTTS"],
   "api_server": ["fastapi", "uvicorn"],
   "bark": [
     "extension_bark @ git+https://github.com/rsxdalv/extension_bark@main"

--- a/gui_pyside6/backend/gtts_backend.py
+++ b/gui_pyside6/backend/gtts_backend.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from gtts import gTTS
+
+
+def synthesize_to_file(
+    text: str,
+    output_path: Path,
+    *,
+    rate: int | None = None,
+    voice: str | None = None,
+    lang: str = "en",
+) -> Path:
+    """Synthesize speech using gTTS and save to an MP3 file."""
+    tts = gTTS(text=text, lang=lang)
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tts.save(str(output_path))
+    return output_path

--- a/gui_pyside6/backend/pyttsx_backend.py
+++ b/gui_pyside6/backend/pyttsx_backend.py
@@ -2,9 +2,20 @@ import pyttsx3
 from pathlib import Path
 
 
-def synthesize_to_file(text: str, output_path: Path) -> Path:
+def synthesize_to_file(
+    text: str,
+    output_path: Path,
+    *,
+    rate: int | None = None,
+    voice: str | None = None,
+    lang: str | None = None,
+) -> Path:
     """Synthesize speech using pyttsx3 and save to a WAV file."""
     engine = pyttsx3.init()
+    if rate is not None:
+        engine.setProperty("rate", rate)
+    if voice is not None:
+        engine.setProperty("voice", voice)
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     engine.save_to_file(text, str(output_path))

--- a/gui_pyside6/planning.md
+++ b/gui_pyside6/planning.md
@@ -13,6 +13,18 @@ This document tracks the initial tasks for building the PySide6 Hybrid TTS appli
 - Created `run_pyside.sh` and `run_pyside.bat` to launch the new GUI.
 - Added dedicated `requirements.in` and `requirements.lock.txt` for the PySide6 GUI.
 - Pruned extension packages from requirements and documented PySide6 launcher in README.
- - **Core requirements remain minimal.** `requirements.uv.toml` lists only the base
+- **Core requirements remain minimal.** `requirements.uv.toml` lists only the base
    dependencies (PySide6, FastAPI, PyTorch, etc.). Optional TTS extensions are
    specified in `backend_requirements.json` and installed on demand at runtime.
+- Implemented an "Open Output Folder" button in the main window that opens the
+  directory of the last synthesized file and uses the existing `open_folder`
+  utility.
+- Add a "Play Last Output" button that uses QtMultimedia to play the most
+  recent WAV file directly in the application.
+- Provide a speech rate selector so users can control the pyttsx3 output speed.
+- Add a voice selector dropdown for pyttsx3 so users can pick from installed
+  voices. Extend the API server to accept `voice` and `rate` parameters.
+- Introduce a gTTS backend for simple online synthesis with MP3 output.
+- Provide a language selector for gTTS so users can choose the output language.
+- Add an "Install Backend" button so users can download optional dependencies
+  when selecting a new backend.

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -1,9 +1,21 @@
 from pathlib import Path
 import subprocess
 import sys
+from datetime import datetime
 from PySide6 import QtWidgets
+from PySide6.QtCore import QUrl
+from PySide6.QtMultimedia import QAudioOutput, QMediaPlayer
 
-from ..backend import BACKENDS, available_backends, ensure_backend_installed
+from ..backend import (
+    BACKENDS,
+    available_backends,
+    ensure_backend_installed,
+    is_backend_installed,
+)
+from ..utils.create_base_filename import create_base_filename
+from ..utils.open_folder import open_folder
+
+OUTPUT_DIR = Path("outputs")
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -25,7 +37,33 @@ class MainWindow(QtWidgets.QMainWindow):
         # Backend dropdown
         self.backend_combo = QtWidgets.QComboBox()
         self.backend_combo.addItems(available_backends())
+        self.backend_combo.currentTextChanged.connect(self.on_backend_changed)
         layout.addWidget(self.backend_combo)
+
+        # Install backend button
+        self.install_button = QtWidgets.QPushButton("Install Backend")
+        self.install_button.clicked.connect(self.on_install_backend)
+        layout.addWidget(self.install_button)
+
+        # Voice selector (pyttsx3 only)
+        self.voice_combo = QtWidgets.QComboBox()
+        self.voice_combo.setEnabled(False)
+        layout.addWidget(self.voice_combo)
+
+        # Language selector (gTTS only)
+        self.lang_combo = QtWidgets.QComboBox()
+        self.lang_combo.setEnabled(False)
+        layout.addWidget(self.lang_combo)
+
+        # Speech rate selector
+        rate_row = QtWidgets.QHBoxLayout()
+        rate_label = QtWidgets.QLabel("Speech Rate:")
+        self.rate_spin = QtWidgets.QSpinBox()
+        self.rate_spin.setRange(50, 300)
+        self.rate_spin.setValue(200)
+        rate_row.addWidget(rate_label)
+        rate_row.addWidget(self.rate_spin)
+        layout.addLayout(rate_row)
 
         # Synthesize button
         self.button = QtWidgets.QPushButton("Synthesize")
@@ -37,11 +75,31 @@ class MainWindow(QtWidgets.QMainWindow):
         self.api_button.clicked.connect(self.on_api_server)
         layout.addWidget(self.api_button)
 
+        # Open output folder button
+        self.open_button = QtWidgets.QPushButton("Open Output Folder")
+        self.open_button.clicked.connect(self.on_open_output)
+        layout.addWidget(self.open_button)
+
+        # Play output button
+        self.play_button = QtWidgets.QPushButton("Play Last Output")
+        self.play_button.clicked.connect(self.on_play_output)
+        self.play_button.setEnabled(False)
+        layout.addWidget(self.play_button)
+
         self.api_process = None
+        self.last_output: Path | None = None
+
+        self.audio_output = QAudioOutput()
+        self.player = QMediaPlayer()
+        self.player.setAudioOutput(self.audio_output)
 
         # Status label
         self.status = QtWidgets.QLabel()
         layout.addWidget(self.status)
+
+        # Load voices for initial backend
+        self.on_backend_changed(self.backend_combo.currentText())
+        self.update_install_status()
 
     def on_synthesize(self):
         text = self.text_edit.toPlainText().strip()
@@ -49,10 +107,19 @@ class MainWindow(QtWidgets.QMainWindow):
             self.status.setText("Please enter some text")
             return
         backend = self.backend_combo.currentText()
-        ensure_backend_installed(backend)
-        output = Path("output.wav")
-        BACKENDS[backend](text, output)
+        if not is_backend_installed(backend):
+            self.status.setText("Backend not installed. Click 'Install Backend' first.")
+            return
+        output = self._generate_output_path(text, backend)
+        rate = self.rate_spin.value()
+        voice_id = self.voice_combo.currentData()
+        lang_code = self.lang_combo.currentData()
+        BACKENDS[backend](
+            text, output, rate=rate, voice=voice_id, lang=lang_code
+        )
+        self.last_output = output
         self.status.setText(f"Saved to {output}")
+        self.play_button.setEnabled(True)
 
     def on_api_server(self):
         if self.api_process is None:
@@ -65,3 +132,77 @@ class MainWindow(QtWidgets.QMainWindow):
             self.status.setText("API server started at http://127.0.0.1:8000")
         else:
             self.status.setText("API server already running")
+
+    def on_open_output(self):
+        folder = self.last_output.parent if self.last_output else OUTPUT_DIR
+        open_folder(str(folder))
+
+    def on_play_output(self):
+        if self.last_output and self.last_output.exists():
+            self.player.setSource(QUrl.fromLocalFile(str(self.last_output)))
+            self.player.play()
+        else:
+            self.status.setText("No output file to play")
+
+    def on_backend_changed(self, backend: str):
+        self.update_install_status()
+        if not is_backend_installed(backend):
+            self.voice_combo.clear()
+            self.voice_combo.setEnabled(False)
+            self.lang_combo.clear()
+            self.lang_combo.setEnabled(False)
+            return
+
+        if backend == "pyttsx3":
+            try:
+                import pyttsx3
+                engine = pyttsx3.init()
+                voices = engine.getProperty("voices")
+            except Exception:
+                voices = []
+            self.voice_combo.clear()
+            self.voice_combo.addItem("(default)", None)
+            for v in voices:
+                name = getattr(v, "name", v.id)
+                self.voice_combo.addItem(name, v.id)
+            self.voice_combo.setEnabled(True)
+            self.lang_combo.clear()
+            self.lang_combo.setEnabled(False)
+        else:
+            self.voice_combo.clear()
+            self.voice_combo.setEnabled(False)
+            if backend == "gtts":
+                try:
+                    from gtts import lang
+                    languages = lang.tts_langs()
+                except Exception:
+                    languages = {"en": "English"}
+                self.lang_combo.clear()
+                for code, name in languages.items():
+                    self.lang_combo.addItem(f"{name} ({code})", code)
+                self.lang_combo.setEnabled(True)
+            else:
+                self.lang_combo.clear()
+                self.lang_combo.setEnabled(False)
+
+    def _generate_output_path(self, text: str, backend: str) -> Path:
+        date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        base = create_base_filename(text[:15], str(OUTPUT_DIR), backend, date)
+        ext = ".mp3" if backend == "gtts" else ".wav"
+        return Path(base + ext)
+
+    def on_install_backend(self):
+        backend = self.backend_combo.currentText()
+        ensure_backend_installed(backend)
+        self.update_install_status()
+        # reload backend specific options
+        self.on_backend_changed(backend)
+
+    def update_install_status(self):
+        backend = self.backend_combo.currentText()
+        if is_backend_installed(backend):
+            self.install_button.setEnabled(False)
+            self.install_button.setText("Backend Installed")
+        else:
+            self.install_button.setEnabled(True)
+            self.install_button.setText("Install Backend")

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -8,6 +8,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 dummy = types.ModuleType("pyttsx3")
 dummy.init = lambda: None
 sys.modules.setdefault("pyttsx3", dummy)
+# Provide a dummy gtts module for the gtts backend
+gtts_dummy = types.ModuleType("gtts")
+gtts_dummy.gTTS = lambda *a, **k: None
+sys.modules.setdefault("gtts", gtts_dummy)
 
 from gui_pyside6.backend import api_server
 
@@ -15,3 +19,10 @@ from gui_pyside6.backend import api_server
 def test_synthesize_route_exists():
     routes = [r.path for r in api_server.app.routes]
     assert "/synthesize" in routes
+
+
+def test_request_model_fields():
+    model = api_server.SynthesisRequest(text="hi")
+    assert hasattr(model, "rate")
+    assert hasattr(model, "voice")
+    assert hasattr(model, "lang")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide dummy TTS modules so backend import works
+import types
+pyttsx3_dummy = types.ModuleType("pyttsx3")
+pyttsx3_dummy.init = lambda: None
+sys.modules.setdefault("pyttsx3", pyttsx3_dummy)
+gtts_dummy = types.ModuleType("gtts")
+gtts_dummy.gTTS = lambda *a, **k: None
+sys.modules.setdefault("gtts", gtts_dummy)
+
+from gui_pyside6.backend import available_backends
+
+
+def test_gtts_backend_available():
+    assert "gtts" in available_backends()

--- a/tests/test_lazy_install.py
+++ b/tests/test_lazy_install.py
@@ -8,8 +8,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 dummy = type(sys)("pyttsx3")
 dummy.init = lambda: None
 sys.modules.setdefault("pyttsx3", dummy)
+# Provide a dummy gtts module so backend import works
+gtts_dummy = type(sys)("gtts")
+gtts_dummy.gTTS = lambda *a, **k: None
+sys.modules.setdefault("gtts", gtts_dummy)
 
-from gui_pyside6.backend import ensure_backend_installed
+from gui_pyside6.backend import ensure_backend_installed, is_backend_installed
 
 
 def test_install_called_when_missing():
@@ -24,3 +28,13 @@ def test_install_skipped_when_present():
         with mock.patch('gui_pyside6.backend.install_package_in_venv') as install:
             ensure_backend_installed('pyttsx3')
             install.assert_not_called()
+
+
+def test_is_backend_installed_true():
+    with mock.patch('importlib.util.find_spec', return_value=object()):
+        assert is_backend_installed('pyttsx3')
+
+
+def test_is_backend_installed_false():
+    with mock.patch('importlib.util.find_spec', return_value=None):
+        assert not is_backend_installed('pyttsx3')


### PR DESCRIPTION
## Summary
- expose `is_backend_installed` to check if a backend's requirements are available
- add Install Backend button in the PySide6 UI and disable synthesize when not installed
- log the feature in planning and salvage docs
- test the install check helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684036b7d53c832987732666ec049005