### PR TITLE
Add MMS backend support

### DIFF
--- a/gui_pyside6/backend/__init__.py
+++ b/gui_pyside6/backend/__init__.py
@@ -21,6 +21,7 @@ BACKENDS = {
     "tortoise": functools.partial(_call_backend, "tortoise_backend", "synthesize_to_file"),
     "edge_tts": functools.partial(_call_backend, "edge_tts_backend", "synthesize_to_file"),
     "demucs": functools.partial(_call_backend, "demucs_backend", "separate_audio"),
+    "mms": functools.partial(_call_backend, "mms_backend", "synthesize_to_file"),
 }
 
 def available_backends():
@@ -43,6 +44,15 @@ def get_gtts_languages():
         return lang.tts_langs()
     except Exception:
         return {"en": "English"}
+
+
+def get_mms_languages() -> list[tuple[str, str]]:
+    """Return list of available MMS languages."""
+    try:
+        from .mms_backend import get_mms_languages as _get
+        return _get()
+    except Exception:
+        return [("English", "eng")]
 
 def missing_backend_packages(name: str) -> list[str]:
     return [pkg for pkg in _get_backend_packages(name) if importlib.util.find_spec(pkg) is None]

--- a/gui_pyside6/backend/mms_backend.py
+++ b/gui_pyside6/backend/mms_backend.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def synthesize_to_file(
+    text: str,
+    output_path: Path,
+    *,
+    language: str = "eng",
+    speaking_rate: float = 1.0,
+    noise_scale: float = 0.667,
+    noise_scale_duration: float = 0.8,
+) -> Path:
+    """Synthesize speech using the MMS TTS model from Facebook.
+
+    Parameters
+    ----------
+    text: str
+        Text to synthesize.
+    output_path: Path
+        Destination WAV file.
+    language: str, optional
+        ISO 639-3 language code, by default "eng".
+    speaking_rate: float, optional
+        Rate multiplier controlling speech speed.
+    noise_scale: float, optional
+        Noise scale parameter.
+    noise_scale_duration: float, optional
+        Noise scale duration parameter.
+    """
+    from transformers import VitsModel, VitsTokenizer
+    import torch
+    import soundfile as sf
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    model = VitsModel.from_pretrained(f"facebook/mms-tts-{language}").to(device)
+    tokenizer = VitsTokenizer.from_pretrained(f"facebook/mms-tts-{language}")
+
+    model.speaking_rate = speaking_rate
+    model.noise_scale = noise_scale
+    model.noise_scale_duration = noise_scale_duration
+
+    inputs = tokenizer(text=text, return_tensors="pt").to(device)
+    with torch.no_grad():
+        outputs = model(**inputs)
+
+    waveform = outputs.waveform[0].cpu().numpy().squeeze()
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(output_path), waveform, model.config.sampling_rate)
+    return output_path
+
+
+def get_mms_languages() -> list[tuple[str, str]]:
+    """Return list of available languages as (name, code) tuples."""
+    try:
+        import importlib.resources as pkg_resources
+        from iso639 import Lang
+        with pkg_resources.open_text(
+            "extension_mms.resources", "mms-languages-iso639-3.txt"
+        ) as f:
+            codes = [line.strip() for line in f if line.strip()]
+        return [(Lang(code).name, code) for code in codes]
+    except Exception:
+        return [("English", "eng")]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -27,7 +27,7 @@ edge_dummy = types.ModuleType("edge_tts")
 edge_dummy.Communicate = lambda *a, **k: type("C", (), {"save": lambda self, p: None})()
 sys.modules.setdefault("edge_tts", edge_dummy)
 
-from gui_pyside6.backend import available_backends
+from gui_pyside6.backend import available_backends, get_mms_languages
 
 
 def test_gtts_backend_available():
@@ -48,3 +48,14 @@ def test_edge_tts_backend_available():
 
 def test_demucs_backend_available():
     assert "demucs" in available_backends()
+
+
+def test_mms_backend_available():
+    assert "mms" in available_backends()
+
+
+def test_get_mms_languages_returns_list():
+    langs = get_mms_languages()
+    assert isinstance(langs, list)
+    assert langs, "Language list should not be empty"
+    assert isinstance(langs[0], tuple) and len(langs[0]) == 2


### PR DESCRIPTION
## Summary
- implement `mms_backend` with language helper
- register `mms` backend and expose language list API
- cover new backend in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684095e786d08329a5de6c2034611a3d