### PR TITLE
Add Vocos audio reconstruction backend

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -35,6 +35,7 @@ Backend packages are defined in `backend/backend_requirements.json`. Installatio
 - Adjustable speech rate.
 - "Play Last Output" and "Open Output Folder" buttons.
 - Optional FastAPI server for programmatic synthesis.
+- Experimental audio reconstruction with **Vocos**.
 
 ## Running Tests
 

--- a/gui_pyside6/backend/__init__.py
+++ b/gui_pyside6/backend/__init__.py
@@ -22,6 +22,7 @@ BACKENDS = {
     "edge_tts": functools.partial(_call_backend, "edge_tts_backend", "synthesize_to_file"),
     "demucs": functools.partial(_call_backend, "demucs_backend", "separate_audio"),
     "mms": functools.partial(_call_backend, "mms_backend", "synthesize_to_file"),
+    "vocos": functools.partial(_call_backend, "vocos_backend", "reconstruct_audio"),
 }
 
 def get_edge_voices(locale: str | None = None) -> list[str]:

--- a/gui_pyside6/backend/vocos_backend.py
+++ b/gui_pyside6/backend/vocos_backend.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def reconstruct_audio(
+    audio_path: Path,
+    output_path: Path,
+    *,
+    bandwidth: int = 0,
+    model_name: str = "charactr/vocos-encodec-24khz",
+) -> Path:
+    """Reconstruct audio using the Vocos neural codec.
+
+    Parameters
+    ----------
+    audio_path: Path
+        Input audio file to process.
+    output_path: Path
+        Destination WAV file.
+    bandwidth: int, optional
+        Bandwidth level index. Defaults to ``0`` which corresponds to
+        1.5 kbps. Higher values use more bandwidth and yield higher quality.
+    model_name: str, optional
+        HuggingFace model identifier. ``charactr/vocos-encodec-24khz`` by default.
+    """
+    import torch
+    import torchaudio
+    from vocos import Vocos
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    vocos = Vocos.from_pretrained(model_name).to(device)
+
+    waveform, sr = torchaudio.load(str(audio_path))
+    if waveform.size(0) > 1:
+        waveform = waveform.mean(dim=0, keepdim=True)
+    waveform = torchaudio.functional.resample(waveform, orig_freq=sr, new_freq=24000)
+    waveform = waveform.to(device)
+
+    with torch.no_grad():
+        bandwidth_id = torch.tensor([bandwidth], device=device)
+        output = vocos(waveform, bandwidth_id=bandwidth_id)
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    torchaudio.save(str(output_path), output.cpu(), 24000)
+    return output_path

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -64,6 +64,10 @@ def test_mms_backend_available():
     assert "mms" in available_backends()
 
 
+def test_vocos_backend_available():
+    assert "vocos" in available_backends()
+
+
 def test_get_mms_languages_returns_list():
     langs = get_mms_languages()
     assert isinstance(langs, list)


### PR DESCRIPTION
## Summary
- add `vocos_backend` for neural audio reconstruction
- expose `vocos` in backend registry
- document Vocos support in README
- test presence of Vocos backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a13b61848329960417b745d00120