### PR TITLE
Fix backend package detection

### DIFF
--- a/tests/test_missing_backend_packages.py
+++ b/tests/test_missing_backend_packages.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from gui_pyside6.backend import missing_backend_packages
+
+
+def test_git_requirement_parsing():
+    checked = []
+    def fake_find_spec(name):
+        checked.append(name)
+        return object()
+
+    with mock.patch('importlib.util.find_spec', side_effect=fake_find_spec):
+        missing = missing_backend_packages('bark')
+
+    assert not missing
+    assert 'extension_bark' in checked
+
+
+def test_case_insensitive_module_name():
+    def fake_find_spec(name):
+        if name == 'gtts':
+            return object()
+        return None
+
+    with mock.patch('importlib.util.find_spec', side_effect=fake_find_spec):
+        missing = missing_backend_packages('gtts')
+
+    assert missing == []
+


### PR DESCRIPTION
## Summary
- parse backend requirement specs to obtain importable module names
- update `missing_backend_packages` to use the parsed module name
- add regression tests for requirement parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a4f01a148329b1de99e111f05f68