### PR TITLE
Improve venv detection for backend installs

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -24,7 +24,7 @@ All Hybrid app code, scripts and dependencies stay inside `/gui_pyside6/`. Do no
 
 Optional TTS backends are installed on demand. Select a backend and click the **Install Backend** button if prompted.
 
-Backend packages are defined in `backend/backend_requirements.json`. Installation first checks if the app is running inside a virtual environment; if so, packages install there. Otherwise they install into a per-user environment at `~/.hybrid_tts/venv` (`C:\Users\USERNAME\.hybrid_tts\venv` on Windows).
+Backend packages are defined in `backend/backend_requirements.json`. Installation first checks if the app is running inside a virtual environment; if so, packages install there. Detection now also considers `VIRTUAL_ENV` or `CONDA_PREFIX` environment variables so Conda and other managers work. If no environment is active, packages install into a per-user environment at `~/.hybrid_tts/venv` (`C:\Users\USERNAME\.hybrid_tts\venv` on Windows).
 
 ## Features
 

--- a/gui_pyside6/SALVAGE_LOG.md
+++ b/gui_pyside6/SALVAGE_LOG.md
@@ -43,3 +43,6 @@ This file tracks files copied or cleaned during the migration to the PySide6 GUI
   packages like `pyttsx3` are only required when their backend is selected.
 - Fixed missing `pip` errors on Windows by bootstrapping with `ensurepip` before
   installing packages and imported `importlib.util` explicitly in the backend.
+- Improved virtual environment detection for backend installation. The helper now
+  also checks `VIRTUAL_ENV` and `CONDA_PREFIX` so Conda environments are handled
+  correctly.

--- a/gui_pyside6/utils/install_utils.py
+++ b/gui_pyside6/utils/install_utils.py
@@ -18,6 +18,17 @@ def _venv_python() -> Path:
     exe = "python.exe" if os.name == "nt" else "python"
     return VENV_DIR / folder / exe
 
+
+def _is_venv_active() -> bool:
+    """Return True if running inside any kind of virtual environment."""
+    if sys.prefix != sys.base_prefix:
+        return True
+    if os.environ.get("VIRTUAL_ENV"):
+        return True
+    if os.environ.get("CONDA_PREFIX"):
+        return True
+    return False
+
 def install_package_in_venv(package: str | Iterable[str]):
     """Install packages into the current venv if active, else into hybrid_tts venv."""
     if isinstance(package, str):
@@ -26,7 +37,7 @@ def install_package_in_venv(package: str | Iterable[str]):
     # Always run ensurepip first so that tests can verify its invocation
     subprocess.run([sys.executable, "-m", "ensurepip", "--upgrade"], check=True)
 
-    in_venv = sys.prefix != sys.base_prefix
+    in_venv = _is_venv_active()
 
     if in_venv:
         print(f"[INFO] Active venv detected → installing into current venv: {sys.prefix}")

--- a/tests/test_install_utils.py
+++ b/tests/test_install_utils.py
@@ -18,3 +18,31 @@ def test_install_package_uses_ensurepip_and_pip():
     # there should be a pip install command at some point
     pip_calls = [c for c in calls if c[0] == 'call' and 'pip' in c[1]]
     assert pip_calls, "pip install was not called"
+
+
+def test_active_env_detected_via_virtual_env_variable():
+    calls = []
+    with mock.patch.dict(os.environ, {"VIRTUAL_ENV": "/tmp/venv"}, clear=True):
+        with mock.patch.object(sys, "prefix", sys.base_prefix), \
+             mock.patch("subprocess.run") as run, \
+             mock.patch("subprocess.check_call") as call:
+            run.side_effect = lambda *a, **k: calls.append(('run', a[0])) or None
+            call.side_effect = lambda *a, **k: calls.append(('call', a[0])) or None
+            install_package_in_venv('dummy')
+
+    python_used = [c for c in calls if c[0] == 'call' and 'pip' in c[1]][0][1][0]
+    assert python_used == sys.executable
+
+
+def test_active_env_detected_via_conda_prefix():
+    calls = []
+    with mock.patch.dict(os.environ, {"CONDA_PREFIX": "/tmp/conda"}, clear=True):
+        with mock.patch.object(sys, "prefix", sys.base_prefix), \
+             mock.patch("subprocess.run") as run, \
+             mock.patch("subprocess.check_call") as call:
+            run.side_effect = lambda *a, **k: calls.append(('run', a[0])) or None
+            call.side_effect = lambda *a, **k: calls.append(('call', a[0])) or None
+            install_package_in_venv('dummy')
+
+    python_used = [c for c in calls if c[0] == 'call' and 'pip' in c[1]][0][1][0]
+    assert python_used == sys.executable


### PR DESCRIPTION
## Summary
- detect virtual envs via `VIRTUAL_ENV` and `CONDA_PREFIX`
- document improved detection in README and SALVAGE_LOG
- add regression tests for new detection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840aa7dad1883298ca45895dbf3ef03