### PR TITLE
Fix run scripts launching from package root

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -15,8 +15,8 @@ All Hybrid app code, scripts and dependencies stay inside `/gui_pyside6/`. Do no
 1. Install **Python 3.11** and the [`uv`](https://github.com/astral-sh/uv) package.
 2. Run `run_pyside.sh` (Linux/macOS) or `run_pyside.bat` (Windows) from this directory.
    The script creates a virtual environment, installs `requirements.uv.toml`,
-   optionally installs PyTorch, and launches the GUI.
-3. You can also start the GUI manually with:
+   optionally installs PyTorch, and launches the GUI from the repository root.
+3. You can also start the GUI manually (from the repository root) with:
 
    ```bash
    python -m gui_pyside6.main
@@ -36,6 +36,15 @@ Backend packages are defined in `backend/backend_requirements.json`. Installatio
 - "Play Last Output" and "Open Output Folder" buttons.
 - Optional FastAPI server for programmatic synthesis.
 - Experimental audio reconstruction with **Vocos**.
+
+## Troubleshooting
+
+- On Windows, the **pyttsx3** backend may fail with `ModuleNotFoundError: No module named 'pywintypes'`.
+  Reinstalling `pywin32` inside the virtual environment usually resolves the issue:
+
+  ```bash
+  pip install --force-reinstall pywin32
+  ```
 
 ## Running Tests
 

--- a/gui_pyside6/run_pyside.bat
+++ b/gui_pyside6/run_pyside.bat
@@ -2,8 +2,10 @@
 setlocal enabledelayedexpansion
 
 :: --- CONFIG ---
-set VENV_DIR=.venv
-set SCRIPT_NAME=main.py
+set SCRIPT_DIR=%~dp0
+set VENV_DIR=%SCRIPT_DIR%\.venv
+set SCRIPT_MODULE=gui_pyside6.main
+cd /d "%SCRIPT_DIR%"
 set WINDOW_TITLE=PySide6 TTS Launcher
 set REQUIREMENTS_INPUT_FILE=requirements.in
 set REQUIREMENTS_LOCK_FILE=requirements.lock.txt
@@ -85,4 +87,6 @@ if "%UV_APP_DRY%"=="0" (
     echo [Dry Run] Skipped PyTorch installation
 )
 
-start "%WINDOW_TITLE%" cmd /k ""%VENV_DIR%\Scripts\python.exe" "%SCRIPT_NAME%""
+pushd ..
+start "%WINDOW_TITLE%" cmd /k ""%VENV_DIR%\Scripts\python.exe" -m %SCRIPT_MODULE%"
+popd

--- a/gui_pyside6/run_pyside.sh
+++ b/gui_pyside6/run_pyside.sh
@@ -9,8 +9,10 @@ REQUIREMENTS_LOCK_FILE="requirements.lock.txt"
 
 
 # --- CONFIG ---
-VENV_DIR=".venv"
-SCRIPT_NAME="main.py"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV_DIR="$SCRIPT_DIR/.venv"
+SCRIPT_MODULE="gui_pyside6.main"
+cd "$SCRIPT_DIR"
 WINDOW_TITLE="PySide6 TTS Launcher"
 
 # Handle dry-run mode
@@ -76,4 +78,6 @@ fi
 
 # Launch app
 echo "Starting application..."
-python "$SCRIPT_NAME"
+pushd "$SCRIPT_DIR/.." >/dev/null
+"$VENV_DIR/bin/python" -m "$SCRIPT_MODULE"
+popd >/dev/null


### PR DESCRIPTION
## Summary
- run the Windows and Linux launchers from the repo root so absolute imports work
- document running the scripts and add troubleshooting note for pywin32

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840b72b397483298e4fb3f47bd4840a