### PR TITLE
Fix backend parameter handling in Hybrid TTS GUI

### DIFF
--- a/gui_pyside6/notes/2025-06-04_investigation.md
+++ b/gui_pyside6/notes/2025-06-04_investigation.md
@@ -31,3 +31,12 @@
 - Consider truncating or warning about very long text inputs to avoid accidentally passing extremely long strings to backends.
 
 These adjustments should eliminate the runtime `TypeError` issues and improve the overall user experience.
+
+## Follow-up 2025-06-04
+
+Implemented dynamic parameter handling in `MainWindow.on_synthesize` so that only
+supported keywords are passed to each backend. The synthesize button is now
+automatically disabled when no text is entered, the selected backend is not
+installed, or synthesis is currently running. Console messages indicate when
+synthesis starts and finishes. Further improvements such as a dedicated stop
+button are still pending.


### PR DESCRIPTION
## Summary
- filter backend kwargs to avoid TypeError
- disable synthesize button when text missing, backend not installed, or synthesis busy
- log synthesize start and finish to console
- document progress in investigation notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c05c1f008329b9e62d56c77a751d