### PR TITLE
Fix synth reset and Edge pitch

### DIFF
--- a/gui_pyside6/backend/edge_tts_backend.py
+++ b/gui_pyside6/backend/edge_tts_backend.py
@@ -7,6 +7,9 @@ from pathlib import Path
 async def _synthesize_async(text: str, output_path: Path, *, voice: str, rate: str, pitch: str | None) -> Path:
     from edge_tts import Communicate
 
+    if not pitch:
+        pitch = "+0Hz"
+
     communicate = Communicate(text=text, voice=voice, rate=rate, pitch=pitch)
     await communicate.save(str(output_path))
     return output_path
@@ -18,7 +21,7 @@ def synthesize_to_file(
     *,
     voice: str = "en-US-GuyNeural",
     rate: str = "+0%",
-    pitch: str | None = None,
+    pitch: str | None = "+0Hz",
 ) -> Path:
     """Synthesize speech using Microsoft Edge TTS service."""
     output_path = Path(output_path)

--- a/gui_pyside6/notes/2025-06-04_investigation.md
+++ b/gui_pyside6/notes/2025-06-04_investigation.md
@@ -40,3 +40,11 @@ automatically disabled when no text is entered, the selected backend is not
 installed, or synthesis is currently running. Console messages indicate when
 synthesis starts and finishes. Further improvements such as a dedicated stop
 button are still pending.
+
+## Follow-up 2025-06-05
+
+Errors raised inside a backend prevented the final `update_synthesize_enabled()`
+call from executing. As a result the **Synthesize** button stayed disabled after
+a failure and the GUI had to be restarted. The `on_synthesize` method now wraps
+the backend call in a `try/except/finally` block so the busy flag is always
+cleared and the button state recovers even if synthesis fails.

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -143,14 +143,19 @@ class MainWindow(QtWidgets.QMainWindow):
             kwargs["lang"] = lang_code
 
         print(f"[INFO] Synthesizing with {backend}...")
-        func(text, output, **kwargs)
-        print(f"[INFO] Output saved to {output}")
-
-        self.last_output = output
-        self.status.setText(f"Saved to {output}")
-        self.play_button.setEnabled(True)
-        self._synth_busy = False
-        self.update_synthesize_enabled()
+        try:
+            func(text, output, **kwargs)
+        except Exception as e:
+            self.status.setText(f"Error: {e}")
+            print(f"[ERROR] {e}")
+        else:
+            print(f"[INFO] Output saved to {output}")
+            self.last_output = output
+            self.status.setText(f"Saved to {output}")
+            self.play_button.setEnabled(True)
+        finally:
+            self._synth_busy = False
+            self.update_synthesize_enabled()
 
     def on_api_server(self):
         if self.api_process is None:


### PR DESCRIPTION
## Summary
- avoid `pitch must be str` in Edge backend by providing a default value
- re-enable synth button even if a backend throws an error
- document the new fix in the investigation notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d1b738848329ad9a530109b589b6