### PR TITLE
Fix Kokoro backend detection

### DIFF
--- a/gui_pyside6/backend/kokoro_backend.py
+++ b/gui_pyside6/backend/kokoro_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import site
 
 
 def synthesize_to_file(
@@ -75,11 +76,20 @@ def list_voices() -> list[tuple[str, str]]:
         import importlib.util
         spec = importlib.util.find_spec("kokoro_fastapi")
         if spec and spec.origin:
-            base = Path(spec.origin).parent
+            base = Path(spec.origin).parent.parent
             voice_dir = base / "api" / "src" / "voices" / "v1_0"
             if voice_dir.exists():
                 voices = [p.stem for p in voice_dir.glob("*.pt")]
-                return [(v, v) for v in sorted(voices)]
+                if voices:
+                    return [(v, v) for v in sorted(voices)]
     except Exception:
         pass
+
+    # Fallback: search all site-packages locations
+    for root in site.getsitepackages():
+        voice_dir = Path(root) / "api" / "src" / "voices" / "v1_0"
+        if voice_dir.exists():
+            voices = [p.stem for p in voice_dir.glob("*.pt")]
+            if voices:
+                return [(v, v) for v in sorted(voices)]
     return []

--- a/gui_pyside6/investigation.md
+++ b/gui_pyside6/investigation.md
@@ -17,3 +17,20 @@ With these changes the Kokoro voice list populates correctly once `extension_kok
 The latest Kokoro releases ship as `kokoro-fastapi` and no longer expose a
 `CHOICES` module. `list_voices()` now falls back to scanning the packaged
 `voices` directory when `extension_kokoro` is missing.
+
+### Follow-up 2
+
+The fallback path originally used `Path(spec.origin).parent`, which resolved to
+`kokoro_fastapi/` inside the package. The voice models reside one directory
+higher under `api/src/voices/v1_0`. Adjusting the path to
+`Path(spec.origin).parent.parent` restores voice detection for the FastAPI
+package.
+
+### Follow-up 3
+
+`is_backend_installed('kokoro')` still returned `False` even after installing
+`kokoro-fastapi` because the helper looked for an importable module name.
+The package exposes its modules under generic names like `inference` and
+`services` so `importlib.util.find_spec("kokoro_fastapi")` failed.  Installation
+checks now rely on `importlib.metadata.distribution` to detect the presence of
+the distribution regardless of module layout.

--- a/gui_pyside6/notes/2025-06-04_investigation.md
+++ b/gui_pyside6/notes/2025-06-04_investigation.md
@@ -243,5 +243,20 @@ obtaining the list of voices. The GUI's voice dropdown stayed empty because the
 collects all `*.pt` files and returns the stem names so the voice selector is
 populated correctly again.
 
+## Follow-up 2025-06-22
+
+Initial implementation used `Path(spec.origin).parent` as the base path when
+locating the voices bundled with the FastAPI package. This resolved to the
+`kokoro_fastapi` package directory and missed the adjacent `api` folder.
+Updating the helper to use `Path(spec.origin).parent.parent` fixes the lookup
+and voice names appear in the dropdown once more.
+
 Further work may be required to integrate the `kokoro-fastapi` API for audio
 generation, but listing voices is operational.
+
+## Follow-up 2025-06-23
+
+`is_backend_installed('kokoro')` failed because it searched for the
+`kokoro_fastapi` module which does not exist. The detection logic now checks
+the installed distribution via `importlib.metadata` so the GUI correctly
+recognizes when Kokoro is present.

--- a/tests/test_lazy_install.py
+++ b/tests/test_lazy_install.py
@@ -14,27 +14,28 @@ gtts_dummy.gTTS = lambda *a, **k: None
 sys.modules.setdefault("gtts", gtts_dummy)
 
 from gui_pyside6.backend import ensure_backend_installed, is_backend_installed
+import importlib.metadata
 
 
 def test_install_called_when_missing():
-    with mock.patch('importlib.util.find_spec', return_value=None):
+    with mock.patch('importlib.metadata.distribution', side_effect=importlib.metadata.PackageNotFoundError):
         with mock.patch('gui_pyside6.backend.install_package_in_venv') as install:
             ensure_backend_installed('pyttsx3')
             install.assert_called_once()
 
 
 def test_install_skipped_when_present():
-    with mock.patch('importlib.util.find_spec', return_value=object()):
+    with mock.patch('importlib.metadata.distribution', return_value=object()):
         with mock.patch('gui_pyside6.backend.install_package_in_venv') as install:
             ensure_backend_installed('pyttsx3')
             install.assert_not_called()
 
 
 def test_is_backend_installed_true():
-    with mock.patch('importlib.util.find_spec', return_value=object()):
+    with mock.patch('importlib.metadata.distribution', return_value=object()):
         assert is_backend_installed('pyttsx3')
 
 
 def test_is_backend_installed_false():
-    with mock.patch('importlib.util.find_spec', return_value=None):
+    with mock.patch('importlib.metadata.distribution', side_effect=importlib.metadata.PackageNotFoundError):
         assert not is_backend_installed('pyttsx3')


### PR DESCRIPTION
## Summary
- check installed distributions with `importlib.metadata`
- search all site-packages for Kokoro voice models
- document the new detection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419a978d8c8329a88fd68237f3c26c