### PR TITLE
Add preferences dialog and uninstall support

### DIFF
--- a/gui_pyside6/ui/preferences.py
+++ b/gui_pyside6/ui/preferences.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from PySide6 import QtWidgets, QtCore
+
+from ..backend import available_backends, is_backend_installed, uninstall_backend
+from ..utils.preferences import load_preferences
+
+
+class PreferencesDialog(QtWidgets.QDialog):
+    def __init__(self, prefs: dict | None = None, parent: QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+        self.setWindowTitle("Preferences")
+        self.prefs = prefs or load_preferences()
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.autoplay_box = QtWidgets.QCheckBox("Auto play after synthesis")
+        self.autoplay_box.setChecked(self.prefs.get("autoplay", True))
+        layout.addWidget(self.autoplay_box)
+
+        self.backend_list = QtWidgets.QListWidget()
+        layout.addWidget(self.backend_list)
+        self.refresh_backends()
+
+        btn_row = QtWidgets.QHBoxLayout()
+        self.uninstall_btn = QtWidgets.QPushButton("Uninstall Selected")
+        self.uninstall_btn.clicked.connect(self.on_uninstall)
+        btn_row.addWidget(self.uninstall_btn)
+        close_btn = QtWidgets.QPushButton("Close")
+        close_btn.clicked.connect(self.accept)
+        btn_row.addWidget(close_btn)
+        layout.addLayout(btn_row)
+
+    def refresh_backends(self) -> None:
+        self.backend_list.clear()
+        for name in available_backends():
+            installed = is_backend_installed(name)
+            item = QtWidgets.QListWidgetItem(f"{name} - {'Installed' if installed else 'Missing'}")
+            item.setData(QtCore.Qt.UserRole, name)
+            self.backend_list.addItem(item)
+            item.setSelected(False)
+
+    def on_uninstall(self) -> None:
+        for item in self.backend_list.selectedItems():
+            backend = item.data(QtCore.Qt.UserRole)
+            uninstall_backend(backend)
+        self.refresh_backends()
+
+    def get_preferences(self) -> dict:
+        return {"autoplay": self.autoplay_box.isChecked()}
+

--- a/gui_pyside6/utils/install_utils.py
+++ b/gui_pyside6/utils/install_utils.py
@@ -62,3 +62,23 @@ def install_package_in_venv(package: str | Iterable[str]):
 
     subprocess.run([str(python_exe), "-m", "ensurepip", "--upgrade"], check=True)
     subprocess.check_call([str(python_exe), "-m", "pip", "install", *package])
+
+
+def uninstall_package_from_venv(package: str | Iterable[str]):
+    """Uninstall packages from the active or hybrid_tts venv."""
+    if isinstance(package, str):
+        package = [package]
+
+    in_venv = _is_venv_active()
+
+    if in_venv:
+        python_exe = sys.executable
+    else:
+        _ensure_venv()
+        python_exe = _venv_python()
+        site_dir = _venv_site_packages()
+        if str(site_dir) not in sys.path:
+            sys.path.insert(0, str(site_dir))
+
+    subprocess.run([str(python_exe), "-m", "ensurepip", "--upgrade"], check=True)
+    subprocess.check_call([str(python_exe), "-m", "pip", "uninstall", "-y", *package])

--- a/gui_pyside6/utils/preferences.py
+++ b/gui_pyside6/utils/preferences.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+PREF_FILE = Path.home() / ".hybrid_tts" / "preferences.json"
+
+
+def load_preferences() -> dict:
+    if PREF_FILE.exists():
+        try:
+            with PREF_FILE.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
+def save_preferences(prefs: dict) -> None:
+    PREF_FILE.parent.mkdir(exist_ok=True)
+    with PREF_FILE.open("w", encoding="utf-8") as f:
+        json.dump(prefs, f, indent=2)


### PR DESCRIPTION
## Summary
- log backend install/uninstall actions
- add uninstall helper in install utils
- expose backend uninstall function
- create a new Preferences dialog with a backend list
- integrate preferences in the main window and persist autoplay setting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841aa3030b88329b22a8029b5c6034c