### PR TITLE
Add uninstall helpers and tests

### DIFF
--- a/gui_pyside6/backend/__init__.py
+++ b/gui_pyside6/backend/__init__.py
@@ -8,7 +8,7 @@ import json
 import sys
 from pathlib import Path
 
-from ..utils.install_utils import install_package_in_venv
+from ..utils.install_utils import install_package_in_venv, uninstall_package_from_venv
 
 def _call_backend(module: str, func: str, *args, **kwargs):
     """Import the given backend module on demand and run the requested function."""
@@ -142,3 +142,12 @@ def ensure_backend_installed(name: str) -> None:
     missing = missing_backend_packages(name)
     if missing:
         install_package_in_venv(missing)
+
+
+def uninstall_backend(name: str) -> None:
+    """Uninstall packages for the given backend using distribution names."""
+    packages = _get_backend_packages(name)
+    if not packages:
+        return
+    dists = [_get_distribution_name(p) for p in packages]
+    uninstall_package_from_venv(dists)

--- a/gui_pyside6/utils/install_utils.py
+++ b/gui_pyside6/utils/install_utils.py
@@ -62,3 +62,20 @@ def install_package_in_venv(package: str | Iterable[str]):
 
     subprocess.run([str(python_exe), "-m", "ensurepip", "--upgrade"], check=True)
     subprocess.check_call([str(python_exe), "-m", "pip", "install", *package])
+
+
+def uninstall_package_from_venv(package: str | Iterable[str]):
+    """Uninstall packages from the current venv if active, else from hybrid_tts venv."""
+    if isinstance(package, str):
+        package = [package]
+
+    in_venv = _is_venv_active()
+
+    if in_venv:
+        python_exe = sys.executable
+    else:
+        _ensure_venv()
+        python_exe = _venv_python()
+
+    subprocess.check_call([str(python_exe), "-m", "pip", "uninstall", "-y", *package])
+

--- a/tests/test_install_utils.py
+++ b/tests/test_install_utils.py
@@ -2,7 +2,7 @@ import os, sys
 from unittest import mock
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from gui_pyside6.utils.install_utils import install_package_in_venv
+from gui_pyside6.utils.install_utils import install_package_in_venv, uninstall_package_from_venv
 
 def test_install_package_uses_ensurepip_and_pip():
     calls = []
@@ -46,3 +46,12 @@ def test_active_env_detected_via_conda_prefix():
 
     python_used = [c for c in calls if c[0] == 'call' and 'pip' in c[1]][0][1][0]
     assert python_used == sys.executable
+
+
+def test_uninstall_package_uses_pip_uninstall():
+    with mock.patch('gui_pyside6.utils.install_utils._is_venv_active', return_value=True), \
+         mock.patch('subprocess.check_call') as call:
+        uninstall_package_from_venv('dummy')
+    call.assert_called_once()
+    args = call.call_args[0][0]
+    assert 'pip' in args and 'uninstall' in args

--- a/tests/test_lazy_install.py
+++ b/tests/test_lazy_install.py
@@ -13,7 +13,7 @@ gtts_dummy = type(sys)("gtts")
 gtts_dummy.gTTS = lambda *a, **k: None
 sys.modules.setdefault("gtts", gtts_dummy)
 
-from gui_pyside6.backend import ensure_backend_installed, is_backend_installed
+from gui_pyside6.backend import ensure_backend_installed, is_backend_installed, uninstall_backend
 import importlib.metadata
 
 
@@ -39,3 +39,10 @@ def test_is_backend_installed_true():
 def test_is_backend_installed_false():
     with mock.patch('importlib.metadata.distribution', side_effect=importlib.metadata.PackageNotFoundError):
         assert not is_backend_installed('pyttsx3')
+
+
+def test_uninstall_backend_passes_distribution_names():
+    with mock.patch('gui_pyside6.backend._get_backend_packages', return_value=['foo==1', 'bar @ git+https://x']):
+        with mock.patch('gui_pyside6.backend.uninstall_package_from_venv') as uninstall:
+            uninstall_backend('dummy')
+            uninstall.assert_called_once_with(['foo', 'bar'])


### PR DESCRIPTION
## Summary
- add `uninstall_package_from_venv` utility and hook up new `uninstall_backend`
- verify pip uninstall runs when uninstalling packages
- test that uninstall_backend passes correct distribution names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b196c5ac8329b758c2f5f996ee95