### PR TITLE
Add Preferences dialog docs

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -37,6 +37,15 @@ Backend packages are defined in `backend/backend_requirements.json`. Installatio
 - Optional FastAPI server for programmatic synthesis.
 - Experimental audio reconstruction with **Vocos**.
 
+## Preferences
+
+Open **Edit → Preferences** to configure the application.
+
+- **Auto play after synthesis** – automatically play generated audio.
+- **Uninstall Backends** – remove optional TTS backends you previously installed.
+
+Your settings are stored in `~/.hybrid_tts/preferences.json`.
+
 ## Troubleshooting
 
 - On Windows, the **pyttsx3** backend may fail with `ModuleNotFoundError: No module named 'pywintypes'`.


### PR DESCRIPTION
## Summary
- document Preferences dialog in the Hybrid README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b2b3e9148329b24a56dddf1050f9