### PR TITLE
Fix Kokoro backend concat bug

### DIFF
--- a/gui_pyside6/backend/kokoro_backend.py
+++ b/gui_pyside6/backend/kokoro_backend.py
@@ -74,7 +74,7 @@ def synthesize_to_file(
     if not audio_parts:
         raise RuntimeError("Kokoro TTS did not return audio")
 
-    audio = torch.cat(audio_parts, dim=1).squeeze().numpy()
+    audio = torch.cat(audio_parts, dim=-1).squeeze().numpy()
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     sf.write(str(output_path), audio, 24000)


### PR DESCRIPTION
## Summary
- fix dimension error in kokoro backend by concatenating audio along the last dimension

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841b7371de88329aa39e4dc60fdeb59