### PR TITLE
Add API server port setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,3 +483,11 @@ This repository includes a lightweight PySide6 launcher for offline TTS.
 5. Optional TTS backends such as `pyttsx3` or `gTTS` are installed on demand.
    Select a backend and click the **Install Backend** button if prompted.
 
+### API Server
+
+Use the **Run API Server** button to launch a FastAPI service (default port
+`8000`). Open `http://localhost:8000/docs` in your browser to explore the API.
+You can change the port via **Edit → Preferences**. If startup fails, check for
+port conflicts with `netstat -ano` on Windows or `lsof -i :<port>` on
+Linux/macOS.
+

--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -46,6 +46,15 @@ Open **Edit → Preferences** to configure the application.
 
 Your settings are stored in `~/.hybrid_tts/preferences.json`.
 
+## API Server
+
+Click **Run API Server** in the main window to start a FastAPI service. By default
+it listens on port `8000`. Visit `http://localhost:8000/docs` in your browser to
+try the interactive API. You can change the listening port via **Edit →
+Preferences** under "API server port". If the server fails to start, check for
+port conflicts using `netstat -ano` on Windows or `lsof -i :<port>` on
+Linux/macOS.
+
 ## Troubleshooting
 
 - On Windows, the **pyttsx3** backend may fail with `ModuleNotFoundError: No module named 'pywintypes'`.

--- a/gui_pyside6/backend/api_server.py
+++ b/gui_pyside6/backend/api_server.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+import argparse
 
 from . import BACKENDS, TRANSCRIBERS
 
@@ -59,11 +60,17 @@ def transcribe(req: TranscriptionRequest):
     return {"text": text}
 
 
-def run_server(host: str = "0.0.0.0", port: int = 8000):
+def run_server(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """Run the FastAPI server using uvicorn."""
     import uvicorn
 
     uvicorn.run(app, host=host, port=port)
 
 
 if __name__ == "__main__":
-    run_server()
+    parser = argparse.ArgumentParser(description="Run the Hybrid TTS API server")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind address")
+    parser.add_argument("--port", type=int, default=8000, help="Listening port")
+    args = parser.parse_args()
+
+    run_server(host=args.host, port=args.port)

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -308,11 +308,18 @@ class MainWindow(QtWidgets.QMainWindow):
         self.api_button.setEnabled(False)
         if self.api_process is None:
             ensure_backend_installed("api_server")
+            port = self.prefs.get("api_port", 8000)
             self.api_process = subprocess.Popen(
-                [sys.executable, "-m", "gui_pyside6.backend.api_server"]
+                [
+                    sys.executable,
+                    "-m",
+                    "gui_pyside6.backend.api_server",
+                    "--port",
+                    str(port),
+                ]
             )
             self.api_button.setText("Stop API Server")
-            self.status.setText("API server started at http://127.0.0.1:8000")
+            self.status.setText(f"API server started at http://127.0.0.1:{port}")
         else:
             self.api_process.terminate()
             self.api_process.wait()
@@ -322,7 +329,8 @@ class MainWindow(QtWidgets.QMainWindow):
         QtCore.QTimer.singleShot(1000, lambda: self.api_button.setEnabled(True))
 
     def on_open_api(self):
-        webbrowser.open("http://127.0.0.1:8000/docs")
+        port = self.prefs.get("api_port", 8000)
+        webbrowser.open(f"http://localhost:{port}/docs")
 
     def on_open_output(self):
         folder = self.last_output.parent if self.last_output else OUTPUT_DIR

--- a/gui_pyside6/ui/preferences.py
+++ b/gui_pyside6/ui/preferences.py
@@ -18,6 +18,15 @@ class PreferencesDialog(QtWidgets.QDialog):
         self.autoplay_box.setChecked(self.prefs.get("autoplay", True))
         layout.addWidget(self.autoplay_box)
 
+        port_row = QtWidgets.QHBoxLayout()
+        port_label = QtWidgets.QLabel("API server port")
+        self.port_spin = QtWidgets.QSpinBox()
+        self.port_spin.setRange(1, 65535)
+        self.port_spin.setValue(self.prefs.get("api_port", 8000))
+        port_row.addWidget(port_label)
+        port_row.addWidget(self.port_spin)
+        layout.addLayout(port_row)
+
         self.backend_list = QtWidgets.QListWidget()
         layout.addWidget(self.backend_list)
         self.refresh_backends()
@@ -47,5 +56,8 @@ class PreferencesDialog(QtWidgets.QDialog):
         self.refresh_backends()
 
     def get_preferences(self) -> dict:
-        return {"autoplay": self.autoplay_box.isChecked()}
+        return {
+            "autoplay": self.autoplay_box.isChecked(),
+            "api_port": self.port_spin.value(),
+        }
 


### PR DESCRIPTION
## Summary
- allow `api_server.py` to read `--host` and `--port`
- store API server port preference and expose it in Preferences dialog
- launch API server using the configured port
- document API server usage and port troubleshooting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d176efc88329ae06b1d7193eb24c