### PR TITLE
Handle demucs multi-file output

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -36,6 +36,8 @@ Backend packages are defined in `backend/backend_requirements.json`. Installatio
 - "Play Last Output" and "Open Output Folder" buttons.
 - Optional FastAPI server for programmatic synthesis.
 - Experimental audio reconstruction with **Vocos**.
+- Music source separation with **Demucs**. Load an audio file and the backend
+  generates individual stem tracks.
 
 ## Preferences
 
@@ -63,6 +65,10 @@ Linux/macOS.
   ```bash
   pip install --force-reinstall pywin32
   ```
+
+- The **Demucs** backend requires the `ffmpeg` command and a valid audio file
+  input. Use the **Load Audio File** button before synthesizing. The generated
+  stem files appear in a new folder under `outputs/`.
 
 ## Running Tests
 

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -27,7 +27,9 @@ MAX_TEXT_LENGTH = 1000
 
 
 class SynthesizeWorker(QtCore.QThread):
-    finished = QtCore.Signal(Path, object)
+    """Run synthesis in a background thread."""
+
+    finished = QtCore.Signal(object, object)
 
     def __init__(self, func, text: str, output: Path, kwargs: dict):
         super().__init__()
@@ -38,11 +40,14 @@ class SynthesizeWorker(QtCore.QThread):
 
     def run(self):
         try:
-            self.func(self.text, self.output, **self.kwargs)
+            result = self.func(self.text, self.output, **self.kwargs)
+            if result is None:
+                result = self.output
             err = None
         except Exception as e:
+            result = None
             err = e
-        self.finished.emit(self.output, err)
+        self.finished.emit(result, err)
 
 class InstallWorker(QtCore.QThread):
     finished = QtCore.Signal(str, object)
@@ -353,19 +358,31 @@ class MainWindow(QtWidgets.QMainWindow):
             self.last_output = path
             self.on_play_output()
 
-    def on_synthesize_finished(self, output: Path, error: object):
+    def on_synthesize_finished(self, result: object, error: object):
+        """Handle completion of the synthesis worker."""
         if error:
             self.status.setText(f"Error: {error}")
             print(f"[ERROR] {error}")
         else:
-            print(f"[INFO] Output saved to {output}")
-            self.last_output = output
-            self.status.setText(f"Saved to {output}")
-            self.play_button.setEnabled(True)
-            self.history_list.insertItem(0, str(output))
+            output_desc = result
+            if isinstance(result, list) and result:
+                # demucs returns a list of stem paths
+                output_desc = result[0].parent
+                self.last_output = result[0]
+            elif isinstance(result, (str, Path)):
+                self.last_output = Path(result)
+            else:
+                self.last_output = None
+
+            print(f"[INFO] Output saved to {output_desc}")
+            self.status.setText(f"Saved to {output_desc}")
+            if self.last_output and self.last_output.exists():
+                self.play_button.setEnabled(True)
+            if isinstance(output_desc, Path):
+                self.history_list.insertItem(0, str(output_desc))
             if self.history_list.count() > 10:
                 self.history_list.takeItem(10)
-            if self.autoplay_check.isChecked():
+            if self.autoplay_check.isChecked() and self.last_output:
                 self.on_play_output()
         self._synth_busy = False
         self.update_synthesize_enabled()


### PR DESCRIPTION
## Summary
- handle arbitrary result type in `SynthesizeWorker`
- support Demucs which returns multiple files
- document Demucs requirement and feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bdf6026c8329afe3a1b4bf6a306e