### PR TITLE
Add output directory preference

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -44,6 +44,7 @@ Backend packages are defined in `backend/backend_requirements.json`. Installatio
 Open **Edit → Preferences** to configure the application.
 
 - **Auto play after synthesis** – automatically play generated audio.
+- **Output directory** – folder where synthesized files are saved. Defaults to `outputs/`.
 - **Uninstall Backends** – remove optional TTS backends you previously installed.
 
 Your settings are stored in `~/.hybrid_tts/preferences.json`.

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -76,6 +76,8 @@ class MainWindow(QtWidgets.QMainWindow):
     def __init__(self):
         super().__init__()
         self.prefs = load_preferences()
+        global OUTPUT_DIR
+        OUTPUT_DIR = Path(self.prefs.get("output_dir", "outputs"))
         self.setWindowTitle("PySide6 TTS Launcher")
         self.resize(400, 200)
 
@@ -556,10 +558,13 @@ class MainWindow(QtWidgets.QMainWindow):
             self.prefs.update(dlg.get_preferences())
             save_preferences(self.prefs)
             self.autoplay_check.setChecked(self.prefs.get("autoplay", True))
+            global OUTPUT_DIR
+            OUTPUT_DIR = Path(self.prefs.get("output_dir", "outputs"))
             self.update_install_status()
 
     def closeEvent(self, event):
         self.prefs["autoplay"] = self.autoplay_check.isChecked()
+        self.prefs["output_dir"] = str(OUTPUT_DIR)
         save_preferences(self.prefs)
         if self.api_process is not None:
             self.api_process.terminate()

--- a/gui_pyside6/ui/preferences.py
+++ b/gui_pyside6/ui/preferences.py
@@ -27,6 +27,17 @@ class PreferencesDialog(QtWidgets.QDialog):
         port_row.addWidget(self.port_spin)
         layout.addLayout(port_row)
 
+        out_row = QtWidgets.QHBoxLayout()
+        out_label = QtWidgets.QLabel("Output directory")
+        self.out_edit = QtWidgets.QLineEdit()
+        self.out_edit.setText(self.prefs.get("output_dir", "outputs"))
+        out_browse = QtWidgets.QPushButton("Browse")
+        out_browse.clicked.connect(self.on_browse_output)
+        out_row.addWidget(out_label)
+        out_row.addWidget(self.out_edit)
+        out_row.addWidget(out_browse)
+        layout.addLayout(out_row)
+
         self.backend_list = QtWidgets.QListWidget()
         layout.addWidget(self.backend_list)
         self.refresh_backends()
@@ -39,6 +50,11 @@ class PreferencesDialog(QtWidgets.QDialog):
         close_btn.clicked.connect(self.accept)
         btn_row.addWidget(close_btn)
         layout.addLayout(btn_row)
+
+    def on_browse_output(self) -> None:
+        folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Select Output Directory", self.out_edit.text())
+        if folder:
+            self.out_edit.setText(folder)
 
     def refresh_backends(self) -> None:
         self.backend_list.clear()
@@ -59,5 +75,6 @@ class PreferencesDialog(QtWidgets.QDialog):
         return {
             "autoplay": self.autoplay_box.isChecked(),
             "api_port": self.port_spin.value(),
+            "output_dir": self.out_edit.text() or "outputs",
         }
 

--- a/tests/test_output_dir_preference.py
+++ b/tests/test_output_dir_preference.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide minimal PySide6 stubs
+class Dummy:
+    def __init__(self, *a, **k):
+        pass
+    def __getattr__(self, name):
+        if name == 'connect':
+            return lambda *a, **k: None
+        return Dummy()
+    def __call__(self, *a, **k):
+        return Dummy()
+
+qtcore = types.ModuleType('QtCore')
+class DummySignal:
+    def __init__(self, *a, **k):
+        pass
+    def connect(self, *a, **k):
+        pass
+    def emit(self, *a, **k):
+        pass
+class DummyQThread:
+    def __init__(self, *a, **k):
+        pass
+qtcore.Signal = DummySignal
+qtcore.QThread = DummyQThread
+qtcore.QUrl = Dummy
+class DummyQtCoreModule(types.ModuleType):
+    def __getattr__(self, name):
+        return Dummy
+qtcore_mod = DummyQtCoreModule('QtCore')
+qtcore_mod.Signal = DummySignal
+qtcore_mod.QThread = DummyQThread
+qtcore_mod.QUrl = Dummy
+qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, UserRole=0)
+
+qtwidgets = types.ModuleType('QtWidgets')
+class DummyQtWidgetsModule(types.ModuleType):
+    def __getattr__(self, name):
+        return Dummy()
+qtwidgets_mod = DummyQtWidgetsModule('QtWidgets')
+qtwidgets_mod.QMainWindow = Dummy
+qtwidgets_mod.QDialog = Dummy
+
+qtmultimedia = types.ModuleType('QtMultimedia')
+qtmultimedia.QAudioOutput = Dummy
+qtmultimedia.QMediaPlayer = Dummy
+
+pyside6 = types.ModuleType('PySide6')
+pyside6.QtCore = qtcore_mod
+pyside6.QtWidgets = qtwidgets_mod
+pyside6.QtMultimedia = qtmultimedia
+sys.modules.setdefault('PySide6', pyside6)
+sys.modules.setdefault('PySide6.QtCore', qtcore_mod)
+sys.modules.setdefault('PySide6.QtWidgets', qtwidgets_mod)
+sys.modules.setdefault('PySide6.QtMultimedia', qtmultimedia)
+
+import importlib
+from gui_pyside6.utils import preferences as prefs
+
+
+def test_output_dir_preference_used(tmp_path):
+    prefs.PREF_FILE = tmp_path / 'prefs.json'
+    output_dir = tmp_path / 'custom_out'
+    prefs.save_preferences({'output_dir': str(output_dir)})
+
+    import gui_pyside6.ui.main_window as main_window
+    importlib.reload(main_window)
+
+    window = main_window.MainWindow()
+    assert main_window.OUTPUT_DIR == output_dir
+    path = window._generate_output_path('hello', 'pyttsx3')
+    assert str(path).startswith(str(output_dir))


### PR DESCRIPTION
## Summary
- allow choosing output directory in PreferencesDialog
- read the preference when creating MainWindow and when updating preferences
- store output_dir in prefs on close
- document the new preference option
- test that the output_dir preference is used when synthesizing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841dc84cf4883298e6f4516e21e825f