### PR TITLE
Fix output handling in on_synthesize_finished

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -370,13 +370,13 @@ class MainWindow(QtWidgets.QMainWindow):
             self.status.setText(f"Error: {error}")
             print(f"[ERROR] {error}")
         else:
-            output_desc = result
-            if isinstance(result, list) and result:
+            output_desc = output
+            if isinstance(output, list) and output:
                 # demucs returns a list of stem paths
-                output_desc = result[0].parent
-                self.last_output = result[0]
-            elif isinstance(result, (str, Path)):
-                self.last_output = Path(result)
+                output_desc = output[0].parent
+                self.last_output = Path(output[0])
+            elif isinstance(output, (str, Path)):
+                self.last_output = Path(output)
             else:
                 self.last_output = None
 


### PR DESCRIPTION
## Summary
- fix references to missing `result` variable
- keep multi-file output support
- ensure playback and history update when output is a path

## Testing
- `pytest tests/test_synthesize_worker.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68422025fb048329bc12e9f60818a295