### PR TITLE
Fix output handling in synthesize callback

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -378,18 +378,19 @@ class MainWindow(QtWidgets.QMainWindow):
             self.on_play_output()
 
 
-    def on_synthesize_finished(self, result: object, error: object, elapsed: float):
+    def on_synthesize_finished(self, output: object, error: object, elapsed: float):
         if error:
             self.status.setText(f"Error: {error}")
             print(f"[ERROR] {error}")
         else:
-            output_desc = result
-            if isinstance(result, list) and result:
+            output_desc = output
+            if isinstance(output, list) and output:
                 # demucs returns a list of stem paths
-                output_desc = result[0].parent
-                self.last_output = Path(result[0])
-            elif isinstance(result, (str, Path)):
-                self.last_output = Path(result)
+                first = Path(output[0])
+                output_desc = first.parent
+                self.last_output = first
+            elif isinstance(output, (str, Path)):
+                self.last_output = Path(output)
             else:
                 self.last_output = None
 

--- a/tests/test_history_list.py
+++ b/tests/test_history_list.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide minimal PySide6 stubs with a working QListWidget
+class Dummy:
+    def __init__(self, *a, **k):
+        pass
+    def __getattr__(self, name):
+        if name == 'connect':
+            return lambda *a, **k: None
+        return Dummy()
+    def __call__(self, *a, **k):
+        return Dummy()
+
+class DummySignal:
+    def __init__(self, *a, **k):
+        pass
+    def connect(self, *a, **k):
+        pass
+    def emit(self, *a, **k):
+        pass
+
+class DummyQThread:
+    def __init__(self, *a, **k):
+        pass
+
+qtcore_mod = types.ModuleType('QtCore')
+qtcore_mod.Signal = DummySignal
+qtcore_mod.QThread = DummyQThread
+qtcore_mod.QUrl = Dummy
+qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, UserRole=0)
+
+class DummyListWidget:
+    def __init__(self, *a, **k):
+        self.items = []
+        self.itemActivated = DummySignal()
+    def insertItem(self, index, text):
+        self.items.insert(index, text)
+    def count(self):
+        return len(self.items)
+    def takeItem(self, index):
+        if len(self.items) > index:
+            self.items.pop(index)
+
+class DummyQtWidgetsModule(types.ModuleType):
+    def __getattr__(self, name):
+        return Dummy
+
+qtwidgets_mod = DummyQtWidgetsModule('QtWidgets')
+qtwidgets_mod.QMainWindow = Dummy
+qtwidgets_mod.QDialog = Dummy
+qtwidgets_mod.QListWidget = DummyListWidget
+qtwidgets_mod.QListWidgetItem = Dummy
+qtwidgets_mod.QPushButton = Dummy
+qtwidgets_mod.QCheckBox = Dummy
+qtwidgets_mod.QPlainTextEdit = Dummy
+qtwidgets_mod.QComboBox = Dummy
+qtwidgets_mod.QHBoxLayout = Dummy
+qtwidgets_mod.QVBoxLayout = Dummy
+qtwidgets_mod.QFormLayout = Dummy
+qtwidgets_mod.QGroupBox = Dummy
+qtwidgets_mod.QSlider = Dummy
+qtwidgets_mod.QLabel = Dummy
+qtwidgets_mod.QSpinBox = Dummy
+
+qtmultimedia = types.ModuleType('QtMultimedia')
+qtmultimedia.QAudioOutput = Dummy
+qtmultimedia.QMediaPlayer = Dummy
+
+pyside6 = types.ModuleType('PySide6')
+pyside6.QtCore = qtcore_mod
+pyside6.QtWidgets = qtwidgets_mod
+pyside6.QtMultimedia = qtmultimedia
+sys.modules.setdefault('PySide6', pyside6)
+sys.modules.setdefault('PySide6.QtCore', qtcore_mod)
+sys.modules.setdefault('PySide6.QtWidgets', qtwidgets_mod)
+sys.modules.setdefault('PySide6.QtMultimedia', qtmultimedia)
+
+import importlib
+from gui_pyside6.utils import preferences as prefs
+
+def test_history_list_populated(tmp_path):
+    prefs.PREF_FILE = tmp_path / 'prefs.json'
+    prefs.save_preferences({})
+
+    import gui_pyside6.ui.main_window as main_window
+    importlib.reload(main_window)
+
+    # ensure backend considered installed
+    main_window.is_backend_installed = lambda name: True
+
+    window = main_window.MainWindow()
+    window.autoplay_check = types.SimpleNamespace(isChecked=lambda: False)
+
+    out_path = tmp_path / 'out.wav'
+    out_path.write_text('x')
+
+    window.on_synthesize_finished(out_path, None, 0.0)
+
+    assert window.last_output == out_path
+    assert window.history_list.items[0] == str(out_path)


### PR DESCRIPTION
## Summary
- rename parameters in `on_synthesize_finished`
- handle list and path outputs consistently
- add regression test for history list population

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422c7e27948329a455806b59599d3d