### PR TITLE
Fix demucs separation with multi-channel audio

### DIFF
--- a/gui_pyside6/backend/demucs_backend.py
+++ b/gui_pyside6/backend/demucs_backend.py
@@ -39,8 +39,11 @@ def separate_audio(
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     f = AudioFile(audio_path)
-    wav = f.read(streams=0, samplerate=model.samplerate)
-    wav = wav.mean(0)
+    wav = f.read(
+        streams=0,
+        samplerate=model.samplerate,
+        channels=model.audio_channels,
+    )
     sources = apply_model(model, wav[None], device=device)[0]
 
     stems = []


### PR DESCRIPTION
## Summary
- adjust demucs backend to read audio with the model's expected number of channels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422cc648e8832996c1ee207635dc4a