### PR TITLE
Show backend info in status

### DIFF
--- a/gui_pyside6/backend/__init__.py
+++ b/gui_pyside6/backend/__init__.py
@@ -52,6 +52,21 @@ BACKEND_FEATURES: dict[str, set[str]] = {
     "whisper": {"file"},
 }
 
+# Short descriptions for each backend shown in the UI
+BACKEND_INFO: dict[str, str] = {
+    "pyttsx3": "Offline TTS engine using system voices.",
+    "gtts": "Google Text-to-Speech (online).",
+    "bark": "Suno Bark generative TTS (experimental).",
+    "tortoise": "Tortoise high quality TTS (experimental).",
+    "edge_tts": "Microsoft Edge cloud voices.",
+    "demucs": "Split audio into vocal/instrument stems.",
+    "mms": "Meta multilingual speech synthesis.",
+    "vocos": "Neural codec audio reconstruction tool.",
+    "kokoro": "Kokoro TTS with voice presets.",
+    "chatterbox": "Voice cloning from prompts.",
+    "whisper": "OpenAI Whisper speech-to-text.",
+}
+
 _LOG_DIR = Path.home() / ".hybrid_tts"
 
 def get_edge_voices(locale: str | None = None) -> list[str]:

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -11,6 +11,7 @@ from PySide6.QtMultimedia import QAudioOutput, QMediaPlayer
 from ..backend import (
     BACKENDS,
     BACKEND_FEATURES,
+    BACKEND_INFO,
     available_backends,
     ensure_backend_installed,
     is_backend_installed,
@@ -430,6 +431,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.cb_voice_button.setText(Path(file_path).name)
 
     def on_backend_changed(self, backend: str):
+        self.status.setText(BACKEND_INFO.get(backend, ""))
         self.update_install_status()
         features = BACKEND_FEATURES.get(backend, set())
 


### PR DESCRIPTION
## Summary
- describe each backend via a new `BACKEND_INFO` map
- display the backend description whenever the backend changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842498825908329b7e90e9ba29d03de