### PR TITLE
Handle path lists in synth results

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -38,6 +38,9 @@ Backend packages are defined in `backend/backend_requirements.json`. Installatio
 - Experimental audio reconstruction with **Vocos**.
 - Music source separation with **Demucs**. Load an audio file and the backend
   generates individual stem tracks.
+- Some tools may output a folder of audio files instead of a single file. The
+  application adds the folder path to the history list and treats the first file
+  as the last output.
 - Optional UI translations. Place custom `.qm` and `.json` files under
   `~/.hybrid_tts/translations`.
 

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -436,10 +436,13 @@ class MainWindow(QtWidgets.QMainWindow):
             else:
                 output_desc = output
                 if isinstance(output, list) and output:
-                    # demucs returns a list of stem paths
-                    first = Path(output[0])
-                    output_desc = first.parent
-                    self.last_output = first
+                    # demucs and future tools may return a list of file paths
+                    if all(isinstance(p, (str, Path)) for p in output):
+                        first = Path(output[0])
+                        output_desc = first.parent
+                        self.last_output = first
+                    else:
+                        self.last_output = None
                 elif isinstance(output, (str, Path)):
                     self.last_output = Path(output)
                 else:

--- a/tests/test_history_list.py
+++ b/tests/test_history_list.py
@@ -143,3 +143,28 @@ def test_transcription_results_displayed(tmp_path):
     assert window.transcript_view.toPlainText() == "hello world"
     assert window.transcript_view.isVisible()
     assert window.history_list.items[0].startswith("Transcribed:")
+
+
+def test_list_of_paths_handled(tmp_path):
+    prefs.PREF_FILE = tmp_path / 'prefs.json'
+    prefs.save_preferences({})
+
+    import importlib
+    import gui_pyside6.ui.main_window as main_window
+    importlib.reload(main_window)
+
+    main_window.is_backend_installed = lambda name: True
+
+    window = main_window.MainWindow()
+    window.autoplay_check = types.SimpleNamespace(isChecked=lambda: False)
+
+    p1 = tmp_path / 'seg1.wav'
+    p2 = tmp_path / 'seg2.wav'
+    p1.write_text('a')
+    p2.write_text('b')
+
+    window.on_synthesize_finished([p1, p2], None, 0.0)
+
+    assert window.last_output == p1
+    assert window.history_list.items[0] == str(tmp_path)
+


### PR DESCRIPTION
## Summary
- improve output handling when synthesis returns a list of paths
- document that some tools create a directory of files
- test list-of-paths handling in history list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842539a4e84832993141f0729d87c7e