### PR TITLE
Implement waveform widget

### DIFF
--- a/gui_pyside6/utils/waveform_plot.py
+++ b/gui_pyside6/utils/waveform_plot.py
@@ -1,0 +1,52 @@
+import io
+import matplotlib
+import matplotlib.figure as mpl_fig
+from matplotlib import pyplot as plt
+import numpy as np
+
+matplotlib.use("agg")
+
+
+def plot_waveform(audio_array: np.ndarray):
+    fig = plt.figure(figsize=(10, 3))
+    plt.style.use("dark_background")
+    plt.plot(audio_array, color="orange")
+    plt.axis("off")
+    return fig
+
+
+def figure_to_image(fig: mpl_fig.Figure):
+    with io.BytesIO() as buff:
+        fig.savefig(buff, format="raw")
+        buff.seek(0)
+        data = np.frombuffer(buff.getvalue(), dtype=np.uint8)
+    w, h = fig.canvas.get_width_height()
+    return data.reshape((int(h), int(w), -1))
+
+
+def plot_waveform_as_image(audio_array: np.ndarray):
+    fig = plot_waveform(audio_array)
+    plt.close()
+    return figure_to_image(fig)
+
+
+def middleware_save_waveform_plot(audio_array: np.ndarray, filename_png: str):
+    # fig = plt.figure(figsize=(10, 3))
+    # plt.style.use("dark_background")
+    # plt.plot(audio_array, color="orange")
+    # plt.axis("off")
+    # plt.savefig(filename_png)
+    # plt.close()
+    fig = plot_waveform(audio_array)
+    plt.savefig(filename_png)
+    plt.close()
+    return figure_to_image(fig)
+
+
+if __name__ == "__main__":
+    print("Testing save_waveform_plot.py")
+    audio_array = np.random.rand(100)
+    filename_png = "test.png"
+    data = middleware_save_waveform_plot(audio_array, filename_png)
+    print(data)
+    print("Testing save_waveform_plot.py done")

--- a/tests/test_history_list.py
+++ b/tests/test_history_list.py
@@ -31,8 +31,12 @@ class DummyQThread:
 qtcore_mod = types.ModuleType('QtCore')
 qtcore_mod.Signal = DummySignal
 qtcore_mod.QThread = DummyQThread
-qtcore_mod.QUrl = Dummy
-qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, UserRole=0)
+class DummyQUrl:
+    @staticmethod
+    def fromLocalFile(p):
+        return p
+qtcore_mod.QUrl = DummyQUrl
+qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, UserRole=0, AlignCenter=0)
 
 class DummyListWidget:
     def __init__(self, *a, **k):
@@ -53,6 +57,13 @@ class DummyQtWidgetsModule(types.ModuleType):
 qtwidgets_mod = DummyQtWidgetsModule('QtWidgets')
 qtwidgets_mod.QMainWindow = Dummy
 qtwidgets_mod.QDialog = Dummy
+qtwidgets_mod.QWidget = Dummy
+class DummyQTabWidget:
+    def __init__(self, *a, **k):
+        self.currentChanged = DummySignal()
+    def addTab(self, *a, **k):
+        pass
+qtwidgets_mod.QTabWidget = DummyQTabWidget
 qtwidgets_mod.QListWidget = DummyListWidget
 qtwidgets_mod.QListWidgetItem = Dummy
 qtwidgets_mod.QPushButton = Dummy
@@ -77,7 +88,14 @@ class DummyPlainTextEdit:
         return self.visible
 
 qtwidgets_mod.QPlainTextEdit = DummyPlainTextEdit
-qtwidgets_mod.QComboBox = Dummy
+class DummyComboBox:
+    def __init__(self, *a, **k):
+        self.currentTextChanged = DummySignal()
+    def addItems(self, *a, **k):
+        pass
+    def __getattr__(self, name):
+        return lambda *a, **k: None
+qtwidgets_mod.QComboBox = DummyComboBox
 qtwidgets_mod.QHBoxLayout = Dummy
 qtwidgets_mod.QVBoxLayout = Dummy
 qtwidgets_mod.QFormLayout = Dummy
@@ -90,14 +108,20 @@ qtmultimedia = types.ModuleType('QtMultimedia')
 qtmultimedia.QAudioOutput = Dummy
 qtmultimedia.QMediaPlayer = Dummy
 
+qtgui_mod = types.ModuleType('QtGui')
+qtgui_mod.QImage = Dummy
+qtgui_mod.QPixmap = Dummy
+
 pyside6 = types.ModuleType('PySide6')
 pyside6.QtCore = qtcore_mod
 pyside6.QtWidgets = qtwidgets_mod
+pyside6.QtGui = qtgui_mod
 pyside6.QtMultimedia = qtmultimedia
-sys.modules.setdefault('PySide6', pyside6)
-sys.modules.setdefault('PySide6.QtCore', qtcore_mod)
-sys.modules.setdefault('PySide6.QtWidgets', qtwidgets_mod)
-sys.modules.setdefault('PySide6.QtMultimedia', qtmultimedia)
+sys.modules['PySide6'] = pyside6
+sys.modules['PySide6.QtCore'] = qtcore_mod
+sys.modules['PySide6.QtWidgets'] = qtwidgets_mod
+sys.modules['PySide6.QtGui'] = qtgui_mod
+sys.modules['PySide6.QtMultimedia'] = qtmultimedia
 
 import importlib
 from gui_pyside6.utils import preferences as prefs

--- a/tests/test_output_dir_preference.py
+++ b/tests/test_output_dir_preference.py
@@ -29,15 +29,19 @@ class DummyQThread:
         pass
 qtcore.Signal = DummySignal
 qtcore.QThread = DummyQThread
-qtcore.QUrl = Dummy
+class DummyQUrl:
+    @staticmethod
+    def fromLocalFile(p):
+        return p
+qtcore.QUrl = DummyQUrl
 class DummyQtCoreModule(types.ModuleType):
     def __getattr__(self, name):
         return Dummy
 qtcore_mod = DummyQtCoreModule('QtCore')
 qtcore_mod.Signal = DummySignal
 qtcore_mod.QThread = DummyQThread
-qtcore_mod.QUrl = Dummy
-qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, UserRole=0)
+qtcore_mod.QUrl = DummyQUrl
+qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, UserRole=0, AlignCenter=0)
 
 qtwidgets = types.ModuleType('QtWidgets')
 class DummyQtWidgetsModule(types.ModuleType):
@@ -46,19 +50,32 @@ class DummyQtWidgetsModule(types.ModuleType):
 qtwidgets_mod = DummyQtWidgetsModule('QtWidgets')
 qtwidgets_mod.QMainWindow = Dummy
 qtwidgets_mod.QDialog = Dummy
+qtwidgets_mod.QWidget = Dummy
+class DummyQTabWidget:
+    def __init__(self, *a, **k):
+        self.currentChanged = DummySignal()
+    def addTab(self, *a, **k):
+        pass
+qtwidgets_mod.QTabWidget = DummyQTabWidget
 
 qtmultimedia = types.ModuleType('QtMultimedia')
 qtmultimedia.QAudioOutput = Dummy
 qtmultimedia.QMediaPlayer = Dummy
 
+qtgui_mod = types.ModuleType('QtGui')
+qtgui_mod.QImage = Dummy
+qtgui_mod.QPixmap = Dummy
+
 pyside6 = types.ModuleType('PySide6')
 pyside6.QtCore = qtcore_mod
 pyside6.QtWidgets = qtwidgets_mod
+pyside6.QtGui = qtgui_mod
 pyside6.QtMultimedia = qtmultimedia
-sys.modules.setdefault('PySide6', pyside6)
-sys.modules.setdefault('PySide6.QtCore', qtcore_mod)
-sys.modules.setdefault('PySide6.QtWidgets', qtwidgets_mod)
-sys.modules.setdefault('PySide6.QtMultimedia', qtmultimedia)
+sys.modules['PySide6'] = pyside6
+sys.modules['PySide6.QtCore'] = qtcore_mod
+sys.modules['PySide6.QtWidgets'] = qtwidgets_mod
+sys.modules['PySide6.QtGui'] = qtgui_mod
+sys.modules['PySide6.QtMultimedia'] = qtmultimedia
 
 import importlib
 from gui_pyside6.utils import preferences as prefs

--- a/tests/test_synthesize_worker.py
+++ b/tests/test_synthesize_worker.py
@@ -27,32 +27,49 @@ class DummyQThread:
         pass
 qtcore.Signal = DummySignal
 qtcore.QThread = DummyQThread
-qtcore.QUrl = Dummy
+class DummyQUrl:
+    @staticmethod
+    def fromLocalFile(p):
+        return p
+qtcore.QUrl = DummyQUrl
 class DummyQtCoreModule(types.ModuleType):
     def __getattr__(self, name):
         return Dummy
 qtcore_mod = DummyQtCoreModule('QtCore')
 qtcore_mod.Signal = DummySignal
 qtcore_mod.QThread = DummyQThread
-qtcore_mod.QUrl = Dummy
+qtcore_mod.QUrl = DummyQUrl
+qtcore_mod.Qt = types.SimpleNamespace(AlignCenter=0, Horizontal=0, UserRole=0)
 
 qtwidgets = types.ModuleType('QtWidgets')
 class DummyQtWidgetsModule(types.ModuleType):
     def __getattr__(self, name):
         return Dummy
 qtwidgets_mod = DummyQtWidgetsModule('QtWidgets')
+class DummyQTabWidget:
+    def __init__(self, *a, **k):
+        self.currentChanged = DummySignal()
+    def addTab(self, *a, **k):
+        pass
+qtwidgets_mod.QTabWidget = DummyQTabWidget
 
 qtmultimedia = types.ModuleType('QtMultimedia')
 qtmultimedia.QAudioOutput = Dummy
 qtmultimedia.QMediaPlayer = Dummy
 
+qtgui_mod = types.ModuleType('QtGui')
+qtgui_mod.QImage = Dummy
+qtgui_mod.QPixmap = Dummy
+
 pyside6 = types.ModuleType('PySide6')
 pyside6.QtCore = qtcore_mod
 pyside6.QtWidgets = qtwidgets_mod
+pyside6.QtGui = qtgui_mod
 pyside6.QtMultimedia = qtmultimedia
-sys.modules.setdefault('PySide6', pyside6)
-sys.modules.setdefault('PySide6.QtCore', qtcore_mod)
-sys.modules.setdefault('PySide6.QtWidgets', qtwidgets_mod)
+sys.modules['PySide6'] = pyside6
+sys.modules['PySide6.QtCore'] = qtcore_mod
+sys.modules['PySide6.QtWidgets'] = qtwidgets_mod
+sys.modules['PySide6.QtGui'] = qtgui_mod
 sys.modules.setdefault('PySide6.QtMultimedia', qtmultimedia)
 
 from gui_pyside6.ui.main_window import SynthesizeWorker

--- a/tests/test_waveform_widget.py
+++ b/tests/test_waveform_widget.py
@@ -1,0 +1,132 @@
+import os
+import sys
+import types
+import numpy as np
+
+matplotlib = types.ModuleType('matplotlib')
+
+class DummyFig:
+    def __init__(self):
+        self.canvas = types.SimpleNamespace(get_width_height=lambda: (1, 1))
+    def savefig(self, buff, format='raw'):
+        buff.write(b'\x00' * 4)
+
+pyplot = types.ModuleType('pyplot')
+pyplot.figure = lambda *a, **k: DummyFig()
+pyplot.style = types.SimpleNamespace(use=lambda *a, **k: None)
+pyplot.plot = lambda *a, **k: None
+pyplot.axis = lambda *a, **k: None
+pyplot.close = lambda *a, **k: None
+matplotlib.use = lambda *a, **k: None
+matplotlib.figure = types.SimpleNamespace(Figure=DummyFig)
+sys.modules.setdefault('matplotlib', matplotlib)
+sys.modules.setdefault('matplotlib.figure', matplotlib.figure)
+sys.modules.setdefault('matplotlib.pyplot', pyplot)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+class Dummy:
+    def __init__(self, *a, **k):
+        pass
+    def __getattr__(self, name):
+        return lambda *a, **k: None
+    def __call__(self, *a, **k):
+        return Dummy()
+
+class DummySignal:
+    def __init__(self, *a, **k):
+        pass
+    def connect(self, *a, **k):
+        pass
+    def emit(self, *a, **k):
+        pass
+
+class DummyQThread:
+    pass
+
+qtcore_mod = types.ModuleType('QtCore')
+qtcore_mod.Signal = DummySignal
+qtcore_mod.QThread = DummyQThread
+class DummyQUrl:
+    @staticmethod
+    def fromLocalFile(p):
+        return p
+qtcore_mod.QUrl = DummyQUrl
+qtcore_mod.Qt = types.SimpleNamespace(AlignCenter=0, Horizontal=0, UserRole=0)
+
+class DummyLabel:
+    def __init__(self, *a, **k):
+        self.pixmap = None
+    def setPixmap(self, p):
+        self.pixmap = p
+    def setScaledContents(self, *a, **k):
+        pass
+    def setAlignment(self, *a, **k):
+        pass
+    def clear(self):
+        self.pixmap = None
+
+qtwidgets_mod = types.ModuleType('QtWidgets')
+qtwidgets_mod.QLabel = DummyLabel
+qtwidgets_mod.QMainWindow = Dummy
+qtwidgets_mod.QDialog = Dummy
+qtwidgets_mod.QWidget = Dummy
+class DummyQTabWidget:
+    def __init__(self, *a, **k):
+        self.currentChanged = DummySignal()
+    def addTab(self, *a, **k):
+        pass
+qtwidgets_mod.QTabWidget = DummyQTabWidget
+qtwidgets_mod.QSlider = Dummy
+qtwidgets_mod.QPushButton = Dummy
+qtwidgets_mod.QCheckBox = Dummy
+qtwidgets_mod.QListWidget = Dummy
+qtwidgets_mod.QPlainTextEdit = Dummy
+qtwidgets_mod.QComboBox = Dummy
+qtwidgets_mod.QHBoxLayout = Dummy
+qtwidgets_mod.QVBoxLayout = Dummy
+qtwidgets_mod.QFormLayout = Dummy
+qtwidgets_mod.QGroupBox = Dummy
+qtwidgets_mod.QSpinBox = Dummy
+qtwidgets_mod.QListWidgetItem = Dummy
+
+class DummyImage:
+    Format_RGBA8888 = 0
+    def __init__(self, *a, **k):
+        pass
+
+class DummyPixmap:
+    @staticmethod
+    def fromImage(img):
+        return 'pixmap'
+
+qtgui_mod = types.ModuleType('QtGui')
+qtgui_mod.QImage = DummyImage
+qtgui_mod.QPixmap = DummyPixmap
+
+qtmultimedia_mod = types.ModuleType('QtMultimedia')
+qtmultimedia_mod.QAudioOutput = Dummy
+qtmultimedia_mod.QMediaPlayer = Dummy
+
+pyside6 = types.ModuleType('PySide6')
+pyside6.QtCore = qtcore_mod
+pyside6.QtWidgets = qtwidgets_mod
+pyside6.QtGui = qtgui_mod
+pyside6.QtMultimedia = qtmultimedia_mod
+sys.modules['PySide6'] = pyside6
+sys.modules['PySide6.QtCore'] = qtcore_mod
+sys.modules['PySide6.QtWidgets'] = qtwidgets_mod
+sys.modules['PySide6.QtGui'] = qtgui_mod
+sys.modules['PySide6.QtMultimedia'] = qtmultimedia_mod
+
+import importlib
+import gui_pyside6.ui.main_window as main_window
+importlib.reload(main_window)
+from gui_pyside6.ui.main_window import WaveformWidget
+
+
+def test_waveform_widget_sets_pixmap():
+    w = WaveformWidget()
+    data = np.zeros(100)
+    w.set_audio_array(data)
+    assert w.pixmap == 'pixmap'


### PR DESCRIPTION
## Summary
- copy waveform plotting utility
- add a simple waveform widget and hook it up
- show playback duration label
- unit test for waveform rendering widget

## Testing
- `pytest -q` *(fails: AttributeError: 'function' object has no attribute 'connect')*

------
https://chatgpt.com/codex/tasks/task_e_684254b511288329a5279ba46f8f5355