### PR TITLE
Fix tab change connection and update status initialization

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -143,7 +143,6 @@ class MainWindow(QtWidgets.QMainWindow):
         # --- Backend selection tabs ---
         model_row = QtWidgets.QHBoxLayout()
         self.tabs = QtWidgets.QTabWidget()
-        safe_connect(self.tabs.currentChanged, self.on_tab_changed)
 
         tts_tab = QtWidgets.QWidget()
         tts_layout = QtWidgets.QVBoxLayout(tts_tab)
@@ -177,6 +176,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.install_button = QtWidgets.QPushButton("Install Backend")
         safe_connect(self.install_button.clicked, self.on_install_backend)
         model_row.addWidget(self.install_button)
+        safe_connect(self.tabs.currentChanged, self.on_tab_changed)
         main_layout.addLayout(model_row)
 
         self.backend_combo = self.tts_combo
@@ -335,7 +335,6 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Load voices for initial backend
         self.on_backend_changed(self.backend_combo.currentText())
-        self.update_install_status()
         self.update_synthesize_enabled()
 
     def on_synthesize(self):


### PR DESCRIPTION
## Summary
- connect `tabs.currentChanged` after creating `install_button`
- remove the duplicate `update_install_status()` call

## Testing
- `pytest -q` *(fails: `__mro_entries__ must return a tuple`)*

------
https://chatgpt.com/codex/tasks/task_e_6842677fa27883299dfc35e48bd89577