### PR TITLE
Limit waveform widget size and improve test stubs

### DIFF
--- a/gui_pyside6/utils/waveform_plot.py
+++ b/gui_pyside6/utils/waveform_plot.py
@@ -8,7 +8,7 @@ matplotlib.use("agg")
 
 
 def plot_waveform(audio_array: np.ndarray):
-    fig = plt.figure(figsize=(10, 3))
+    fig = plt.figure(figsize=(6, 2))
     plt.style.use("dark_background")
     plt.plot(audio_array, color="orange")
     plt.axis("off")


### PR DESCRIPTION
## Summary
- add fixed max height and aspect scaling to `WaveformWidget`
- produce smaller waveform images
- provide stub fallbacks for widgets when PySide6 features are missing
- make status/text handling tolerant of dummy widgets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684269a19c1c832998c3eb254cda0867