### PR TITLE
Add scroll area in MainWindow

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -177,8 +177,16 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle("PySide6 TTS Launcher")
         self.resize(400, 200)
 
-        central = QtWidgets.QWidget()
-        self.setCentralWidget(central)
+        if hasattr(QtWidgets, "QScrollArea"):
+            scroll = QtWidgets.QScrollArea()
+            scroll.setWidgetResizable(True)
+            self.setCentralWidget(scroll)
+
+            central = QtWidgets.QWidget()
+            scroll.setWidget(central)
+        else:
+            central = QtWidgets.QWidget()
+            self.setCentralWidget(central)
 
         main_layout = QtWidgets.QVBoxLayout(central)
 


### PR DESCRIPTION
## Summary
- wrap main layout in a `QScrollArea` so overflowing widgets can scroll
- keep previous behaviour when `QScrollArea` isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68426e74cb608329a64fd423d39e3197