### PR TITLE
Enable resizable waveform widget

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -91,9 +91,7 @@ class WaveformWidget(LabelBase):
         if hasattr(self, "setAlignment"):
             self.setAlignment(QtCore.Qt.AlignCenter)
         if hasattr(self, "setScaledContents"):
-            self.setScaledContents(False)
-        if hasattr(self, "setMaximumHeight"):
-            self.setMaximumHeight(120)
+            self.setScaledContents(True)
         self._pixmap_orig = None
         self._playback_ratio = 0.0
 

--- a/gui_pyside6/utils/waveform_plot.py
+++ b/gui_pyside6/utils/waveform_plot.py
@@ -8,7 +8,7 @@ matplotlib.use("agg")
 
 
 def plot_waveform(audio_array: np.ndarray):
-    fig = plt.figure(figsize=(6, 2))
+    fig = plt.figure(figsize=(8, 2.5))
     plt.style.use("dark_background")
     plt.plot(audio_array, color="orange")
     plt.axis("off")


### PR DESCRIPTION
## Summary
- allow waveform QLabel to expand and scale with the window
- bump Matplotlib waveform figure dimensions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428923ade4832991d1318e57d9e772