### PR TITLE
Add backend metadata and update installer

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -25,6 +25,7 @@ All Hybrid app code, scripts and dependencies stay inside `/gui_pyside6/`. Do no
 Optional TTS backends are installed on demand. Select a backend and click the **Install Backend** button if prompted.
 
 Backend packages are defined in `backend/backend_requirements.json`. Installation first checks if the app is running inside a virtual environment; if so, packages install there. Detection now also considers `VIRTUAL_ENV` or `CONDA_PREFIX` environment variables so Conda and other managers work. If no environment is active, packages install into a per-user environment at `~/.hybrid_tts/venv` (`C:\Users\USERNAME\.hybrid_tts\venv` on Windows).
+Metadata files under `backend/metadata/` record the primary package name and repository URL for each backend.
 
 ## Features
 

--- a/gui_pyside6/backend/bark_backend.py
+++ b/gui_pyside6/backend/bark_backend.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 
 # Bark is a heavy dependency that may not be installed by default.
-# The backend_requirements.json maps the "bark" backend to
-# `extension_bark` which provides the Bark TTS implementation.
-# This backend provides a thin wrapper that calls the library if present.
+# Metadata in ``backend/metadata/bark.toml`` describes the package
+# and repository used for installation. This backend provides a thin
+# wrapper that calls the library if present.
 
 def synthesize_to_file(
     text: str,

--- a/gui_pyside6/backend/metadata/bark.toml
+++ b/gui_pyside6/backend/metadata/bark.toml
@@ -1,0 +1,3 @@
+package = "bark"
+repo_url = "https://github.com/suno-ai/bark"
+description = "Suno Bark generative TTS (experimental)."

--- a/gui_pyside6/backend/metadata/chatterbox.toml
+++ b/gui_pyside6/backend/metadata/chatterbox.toml
@@ -1,0 +1,3 @@
+package = "chatterbox-tts"
+repo_url = "https://github.com/resemble-ai/chatterbox"
+description = "Voice cloning from prompts."

--- a/gui_pyside6/backend/metadata/demucs.toml
+++ b/gui_pyside6/backend/metadata/demucs.toml
@@ -1,0 +1,3 @@
+package = "demucs"
+repo_url = "https://github.com/facebookresearch/demucs"
+description = "Split audio into vocal/instrument stems."

--- a/gui_pyside6/backend/metadata/edge_tts.toml
+++ b/gui_pyside6/backend/metadata/edge_tts.toml
@@ -1,0 +1,3 @@
+package = "edge-tts"
+repo_url = "https://github.com/rany2/edge-tts"
+description = "Microsoft Edge cloud voices."

--- a/gui_pyside6/backend/metadata/gtts.toml
+++ b/gui_pyside6/backend/metadata/gtts.toml
@@ -1,0 +1,3 @@
+package = "gTTS"
+repo_url = "https://github.com/pndurette/gTTS"
+description = "Google Text-to-Speech (online)."

--- a/gui_pyside6/backend/metadata/kokoro.toml
+++ b/gui_pyside6/backend/metadata/kokoro.toml
@@ -1,0 +1,3 @@
+package = "kokoro"
+repo_url = "https://github.com/hexgrad/kokoro"
+description = "Kokoro TTS with voice presets."

--- a/gui_pyside6/backend/metadata/mms.toml
+++ b/gui_pyside6/backend/metadata/mms.toml
@@ -1,0 +1,3 @@
+package = "transformers"
+repo_url = "https://github.com/facebookresearch/seamless_communication"
+description = "Meta multilingual speech synthesis."

--- a/gui_pyside6/backend/metadata/pyttsx3.toml
+++ b/gui_pyside6/backend/metadata/pyttsx3.toml
@@ -1,0 +1,3 @@
+package = "pyttsx3"
+repo_url = "https://github.com/nateshmbhat/pyttsx3"
+description = "Offline TTS engine using system voices."

--- a/gui_pyside6/backend/metadata/tortoise.toml
+++ b/gui_pyside6/backend/metadata/tortoise.toml
@@ -1,0 +1,3 @@
+package = "tortoise-tts"
+repo_url = "https://github.com/neonbjb/tortoise-tts"
+description = "Tortoise high quality TTS (experimental)."

--- a/gui_pyside6/backend/metadata/vocos.toml
+++ b/gui_pyside6/backend/metadata/vocos.toml
@@ -1,0 +1,3 @@
+package = "vocos"
+repo_url = "https://github.com/charactr-platform/vocos"
+description = "Neural codec audio reconstruction tool."

--- a/gui_pyside6/backend/metadata/whisper.toml
+++ b/gui_pyside6/backend/metadata/whisper.toml
@@ -1,0 +1,3 @@
+package = "openai-whisper"
+repo_url = "https://github.com/openai/whisper"
+description = "OpenAI Whisper speech-to-text."

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -12,6 +12,7 @@ from ..backend import (
     BACKENDS,
     BACKEND_FEATURES,
     BACKEND_INFO,
+    get_backend_repo,
     TTS_BACKENDS,
     TOOL_BACKENDS,
     EXPERIMENTAL_BACKENDS,
@@ -810,7 +811,11 @@ class MainWindow(QtWidgets.QMainWindow):
     def on_install_backend(self):
         backend = self.backend_combo.currentText()
         self.install_button.setEnabled(False)
-        self.status.setText(f"Installing {backend}...")
+        repo = get_backend_repo(backend)
+        if repo:
+            self.status.setText(f"Installing {backend} from {repo}...")
+        else:
+            self.status.setText(f"Installing {backend}...")
         self.install_worker = InstallWorker(backend)
         self.install_worker.finished.connect(self.on_install_finished)
         self.install_worker.start()


### PR DESCRIPTION
## Summary
- document packages and repo URLs for each backend in new metadata files
- load metadata in `backend.__init__` and provide helper functions
- adjust Bark backend comment
- show repo URLs during installation
- mention metadata in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428d4486f08329af4c97dfd70ceb30