### PR TITLE
Allow kokoro-fastapi to satisfy kokoro backend

### DIFF
--- a/gui_pyside6/backend/__init__.py
+++ b/gui_pyside6/backend/__init__.py
@@ -172,6 +172,19 @@ def get_mms_languages() -> list[tuple[str, str]]:
         return [("English", "eng")]
 
 def missing_backend_packages(name: str) -> list[str]:
+    """Return a list of required packages that are not currently installed."""
+
+    # The Kokoro backend can be satisfied by either the ``kokoro`` or
+    # ``kokoro-fastapi`` distribution.  Treat the backend as installed if either
+    # package is present.
+    if name == "kokoro":
+        for candidate in ("kokoro", "kokoro-fastapi"):
+            try:
+                metadata.distribution(candidate)
+                return []
+            except metadata.PackageNotFoundError:
+                continue
+
     missing = []
     for pkg in _get_backend_packages(name):
         dist_name = _get_distribution_name(pkg)

--- a/tests/test_lazy_install.py
+++ b/tests/test_lazy_install.py
@@ -41,6 +41,16 @@ def test_is_backend_installed_false():
         assert not is_backend_installed('pyttsx3')
 
 
+def test_kokoro_fastapi_is_recognized():
+    def fake_distribution(name):
+        if name == 'kokoro-fastapi':
+            return object()
+        raise importlib.metadata.PackageNotFoundError
+
+    with mock.patch('importlib.metadata.distribution', side_effect=fake_distribution):
+        assert is_backend_installed('kokoro')
+
+
 def test_uninstall_backend_passes_distribution_names():
     with mock.patch('gui_pyside6.backend._get_backend_packages', return_value=['foo==1', 'bar @ git+https://x']):
         with mock.patch('gui_pyside6.backend.uninstall_package_from_venv') as uninstall:

--- a/tests/test_missing_backend_packages.py
+++ b/tests/test_missing_backend_packages.py
@@ -35,3 +35,18 @@ def test_case_insensitive_module_name():
 
     assert missing == []
 
+
+def test_kokoro_fastapi_counts_as_installed():
+    """``kokoro-fastapi`` should satisfy the ``kokoro`` backend."""
+
+    def fake_distribution(name):
+        if name == 'kokoro-fastapi':
+            class D: ...
+            return D()
+        raise importlib.metadata.PackageNotFoundError
+
+    with mock.patch('importlib.metadata.distribution', side_effect=fake_distribution):
+        missing = missing_backend_packages('kokoro')
+
+    assert missing == []
+


### PR DESCRIPTION
## Summary
- detect kokoro-fastapi in `missing_backend_packages`
- treat kokoro-fastapi as valid installation in lazy install helper
- test kokoro-fastapi handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684299cd02ec8329b60cb9b2a52c6fb8