### PR TITLE
Update Demucs history handling

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -621,13 +621,19 @@ class MainWindow(QtWidgets.QMainWindow):
                 if isinstance(output, list) and output:
                     # demucs and future tools may return a list of file paths
                     if all(isinstance(p, (str, Path)) for p in output):
-                        first = Path(output[0])
+                        paths = [Path(p) for p in output]
+                        first = paths[0]
                         output_desc = first.parent
                         self.last_output = first
+                        for p in reversed(paths):
+                            self.history_list.insertItem(0, str(p))
                     else:
                         self.last_output = None
                 elif isinstance(output, (str, Path)):
-                    self.last_output = Path(output)
+                    p = Path(output)
+                    self.last_output = p
+                    output_desc = p
+                    self.history_list.insertItem(0, str(p))
                 else:
                     self.last_output = None
 
@@ -636,7 +642,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.status.setText(f"Saved to {output_desc}")
                 if self.last_output and self.last_output.exists():
                     self.play_button.setEnabled(True)
-                if isinstance(output_desc, Path):
+                if isinstance(output_desc, Path) and not isinstance(output, list):
                     self.history_list.insertItem(0, str(output_desc))
                 if self.autoplay_check.isChecked() and self.last_output:
                     self.on_play_output()

--- a/tests/test_history_list.py
+++ b/tests/test_history_list.py
@@ -190,5 +190,6 @@ def test_list_of_paths_handled(tmp_path):
     window.on_synthesize_finished([p1, p2], None, 0.0)
 
     assert window.last_output == p1
-    assert window.history_list.items[0] == str(tmp_path)
+    assert window.history_list.items[0] == str(p1)
+    assert window.history_list.items[1] == str(p2)
 


### PR DESCRIPTION
## Summary
- show each Demucs output file in the history list
- update test to expect multiple entries for path lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429c7be9d483298f3610223fe8cea2