### PR TITLE
Add waveform next to backend tabs

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -283,6 +283,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
         model_row.addWidget(self.tabs)
 
+        self.waveform = WaveformWidget()
+        if hasattr(self.waveform, "setFixedWidth"):
+            self.waveform.setFixedWidth(200)
+        self.waveform._update_scaled_pixmap()
+        model_row.addWidget(self.waveform)
+
         self.install_button = QtWidgets.QPushButton("Install Backend")
         safe_connect(self.install_button.clicked, self.on_install_backend)
         model_row.addWidget(self.install_button)
@@ -400,8 +406,7 @@ class MainWindow(QtWidgets.QMainWindow):
         transcript_layout.addWidget(self.transcript_view)
         self.transcript_group.setVisible(False)
 
-        self.waveform = WaveformWidget()
-        player_layout.addWidget(self.waveform)
+
 
         # --- Mini player row ---
         player_row = QtWidgets.QHBoxLayout()
@@ -886,6 +891,11 @@ class MainWindow(QtWidgets.QMainWindow):
         if not file_based:
             self.audio_file = None
             self.load_audio_button.setText("Load Audio File")
+        parent = getattr(self.text_edit, "parentWidget", lambda: None)()
+        layout = getattr(parent, "layout", lambda: None)()
+        if layout is not None and hasattr(layout, "invalidate"):
+            layout.invalidate()
+        self.waveform._update_scaled_pixmap()
 
         self.chatterbox_opts.setVisible(backend == "chatterbox")
         self.update_synthesize_enabled()


### PR DESCRIPTION
## Summary
- show audio waveform beside backend tabs
- keep player panel less crowded
- refresh layout properly when backend switches file/text modes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a8db9994832984b810e8f64bbfd0