### PR TITLE
Switch volume slider to vertical

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -408,12 +408,16 @@ class MainWindow(QtWidgets.QMainWindow):
             self.waveform.setFixedWidth(200)
         self.waveform._update_scaled_pixmap()
         player_row.addWidget(self.waveform)
-        self.volume_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.volume_slider = QtWidgets.QSlider(QtCore.Qt.Vertical)
         self.volume_slider.setRange(0, 100)
         self.volume_slider.setValue(100)
-        player_row.addWidget(self.volume_slider)
+        if hasattr(self.volume_slider, "setFixedHeight"):
+            self.volume_slider.setFixedHeight(80)
+        volume_col = QtWidgets.QVBoxLayout()
+        volume_col.addWidget(self.volume_slider)
         self.volume_label = QtWidgets.QLabel("100%")
-        player_row.addWidget(self.volume_label)
+        volume_col.addWidget(self.volume_label)
+        player_row.addLayout(volume_col)
         player_layout.addLayout(player_row)
 
         # Autoplay option

--- a/tests/test_history_list.py
+++ b/tests/test_history_list.py
@@ -36,7 +36,7 @@ class DummyQUrl:
     def fromLocalFile(p):
         return p
 qtcore_mod.QUrl = DummyQUrl
-qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, UserRole=0, AlignCenter=0)
+qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, Vertical=1, UserRole=0, AlignCenter=0)
 
 class DummyListWidget:
     def __init__(self, *a, **k):
@@ -121,7 +121,11 @@ qtmultimedia.QMediaPlayer = Dummy
 
 qtgui_mod = types.ModuleType('QtGui')
 qtgui_mod.QImage = Dummy
-qtgui_mod.QPixmap = Dummy
+class DummyPixmap:
+    @staticmethod
+    def fromImage(img):
+        return 'pixmap'
+qtgui_mod.QPixmap = DummyPixmap
 
 pyside6 = types.ModuleType('PySide6')
 pyside6.QtCore = qtcore_mod

--- a/tests/test_on_install_finished.py
+++ b/tests/test_on_install_finished.py
@@ -43,7 +43,7 @@ def _setup_pyside6_stubs():
         def fromLocalFile(p):
             return p
     qtcore_mod.QUrl = DummyQUrl
-    qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, UserRole=0, AlignCenter=0)
+    qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, Vertical=1, UserRole=0, AlignCenter=0)
 
     class DummyComboBox:
         def __init__(self, *a, **k):
@@ -121,7 +121,11 @@ def _setup_pyside6_stubs():
 
     qtgui_mod = types.ModuleType('QtGui')
     qtgui_mod.QImage = Dummy
-    qtgui_mod.QPixmap = Dummy
+    class DummyPixmap:
+        @staticmethod
+        def fromImage(img):
+            return 'pixmap'
+    qtgui_mod.QPixmap = DummyPixmap
 
     pyside6 = types.ModuleType('PySide6')
     pyside6.QtCore = qtcore_mod

--- a/tests/test_output_dir_preference.py
+++ b/tests/test_output_dir_preference.py
@@ -41,7 +41,7 @@ qtcore_mod = DummyQtCoreModule('QtCore')
 qtcore_mod.Signal = DummySignal
 qtcore_mod.QThread = DummyQThread
 qtcore_mod.QUrl = DummyQUrl
-qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, UserRole=0, AlignCenter=0)
+qtcore_mod.Qt = types.SimpleNamespace(Horizontal=0, Vertical=1, UserRole=0, AlignCenter=0)
 
 qtwidgets = types.ModuleType('QtWidgets')
 class DummyQtWidgetsModule(types.ModuleType):
@@ -64,7 +64,11 @@ qtmultimedia.QMediaPlayer = Dummy
 
 qtgui_mod = types.ModuleType('QtGui')
 qtgui_mod.QImage = Dummy
-qtgui_mod.QPixmap = Dummy
+class DummyPixmap:
+    @staticmethod
+    def fromImage(img):
+        return 'pixmap'
+qtgui_mod.QPixmap = DummyPixmap
 
 pyside6 = types.ModuleType('PySide6')
 pyside6.QtCore = qtcore_mod

--- a/tests/test_synthesize_worker.py
+++ b/tests/test_synthesize_worker.py
@@ -39,7 +39,7 @@ qtcore_mod = DummyQtCoreModule('QtCore')
 qtcore_mod.Signal = DummySignal
 qtcore_mod.QThread = DummyQThread
 qtcore_mod.QUrl = DummyQUrl
-qtcore_mod.Qt = types.SimpleNamespace(AlignCenter=0, Horizontal=0, UserRole=0)
+qtcore_mod.Qt = types.SimpleNamespace(AlignCenter=0, Horizontal=0, Vertical=1, UserRole=0)
 
 qtwidgets = types.ModuleType('QtWidgets')
 class DummyQtWidgetsModule(types.ModuleType):
@@ -59,7 +59,11 @@ qtmultimedia.QMediaPlayer = Dummy
 
 qtgui_mod = types.ModuleType('QtGui')
 qtgui_mod.QImage = Dummy
-qtgui_mod.QPixmap = Dummy
+class DummyPixmap:
+    @staticmethod
+    def fromImage(img):
+        return 'pixmap'
+qtgui_mod.QPixmap = DummyPixmap
 
 pyside6 = types.ModuleType('PySide6')
 pyside6.QtCore = qtcore_mod

--- a/tests/test_waveform_widget.py
+++ b/tests/test_waveform_widget.py
@@ -52,7 +52,7 @@ class DummyQUrl:
     def fromLocalFile(p):
         return p
 qtcore_mod.QUrl = DummyQUrl
-qtcore_mod.Qt = types.SimpleNamespace(AlignCenter=0, Horizontal=0, UserRole=0)
+qtcore_mod.Qt = types.SimpleNamespace(AlignCenter=0, Horizontal=0, Vertical=1, UserRole=0)
 
 class DummyLabel:
     def __init__(self, *a, **k):
@@ -77,7 +77,22 @@ class DummyQTabWidget:
     def addTab(self, *a, **k):
         pass
 qtwidgets_mod.QTabWidget = DummyQTabWidget
-qtwidgets_mod.QSlider = Dummy
+class DummyQSlider:
+    def __init__(self, orientation=0):
+        self._orientation = orientation
+        self.valueChanged = DummySignal()
+        self._value = 0
+    def setRange(self, *a, **k):
+        pass
+    def setValue(self, v, *a, **k):
+        self._value = v
+    def value(self):
+        return self._value
+    def setFixedHeight(self, *a, **k):
+        pass
+    def orientation(self):
+        return self._orientation
+qtwidgets_mod.QSlider = DummyQSlider
 qtwidgets_mod.QPushButton = Dummy
 qtwidgets_mod.QCheckBox = Dummy
 qtwidgets_mod.QListWidget = Dummy
@@ -122,7 +137,7 @@ sys.modules['PySide6.QtMultimedia'] = qtmultimedia_mod
 import importlib
 import gui_pyside6.ui.main_window as main_window
 importlib.reload(main_window)
-from gui_pyside6.ui.main_window import WaveformWidget
+from gui_pyside6.ui.main_window import WaveformWidget, MainWindow
 
 
 def test_waveform_widget_sets_pixmap():
@@ -130,3 +145,8 @@ def test_waveform_widget_sets_pixmap():
     data = np.zeros(100)
     w.set_audio_array(data)
     assert w.pixmap == 'pixmap'
+
+
+def test_volume_slider_orientation_vertical():
+    window = MainWindow()
+    assert window.volume_slider.orientation() == main_window.QtCore.Qt.Vertical


### PR DESCRIPTION
## Summary
- change volume slider orientation to vertical in the PySide6 UI
- adjust layout to keep label underneath
- expand PySide6 stubs for `Qt.Vertical` and `QPixmap` across tests
- add test checking vertical orientation of the slider

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842eaac20a88329b71477bf84670c1c