### PR TITLE
Add root route with status test

### DIFF
--- a/gui_pyside6/backend/api_server.py
+++ b/gui_pyside6/backend/api_server.py
@@ -12,6 +12,12 @@ from . import BACKENDS, TRANSCRIBERS
 app = FastAPI(title="Hybrid TTS API")
 
 
+@app.get("/", include_in_schema=False)
+def index() -> dict[str, str]:
+    """Simple health endpoint for the API."""
+    return {"message": "Hybrid TTS API"}
+
+
 class SynthesisRequest(BaseModel):
     text: str
     backend: str = "pyttsx3"

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -14,6 +14,7 @@ gtts_dummy.gTTS = lambda *a, **k: None
 sys.modules.setdefault("gtts", gtts_dummy)
 
 from gui_pyside6.backend import api_server
+from fastapi.testclient import TestClient
 
 
 def test_synthesize_route_exists():
@@ -42,3 +43,9 @@ def test_transcription_request_fields():
     model = api_server.TranscriptionRequest(audio="audio.wav")
     assert hasattr(model, "backend")
     assert hasattr(model, "model")
+
+
+def test_root_returns_200():
+    client = TestClient(api_server.app)
+    resp = client.get("/")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add a root endpoint in `api_server` returning a small JSON
- ensure GET `/` returns HTTP 200 in API server tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842edb3fce88329b0fbee0b7f9cca69