### PR TITLE
Fix transcriber invocation

### DIFF
--- a/tests/test_history_list.py
+++ b/tests/test_history_list.py
@@ -252,7 +252,7 @@ def test_whisper_does_not_leave_busy(tmp_path):
     importlib.reload(main_window)
 
     main_window.is_backend_installed = lambda name: True
-    main_window.TRANSCRIBERS['whisper'] = lambda audio, output, **kw: 'ok'
+    main_window.TRANSCRIBERS['whisper'] = lambda audio, **kw: 'ok'
 
     class DummyWorker:
         def __init__(self, func, text, output, kwargs):
@@ -263,7 +263,10 @@ def test_whisper_does_not_leave_busy(tmp_path):
             self.finished = types.SimpleNamespace(connect=lambda cb: setattr(self, '_cb', cb))
 
         def start(self):
-            result = self.func(self.text, self.output, **self.kwargs)
+            if self.output is not None:
+                result = self.func(self.text, self.output, **self.kwargs)
+            else:
+                result = self.func(self.text, **self.kwargs)
             if hasattr(self, '_cb'):
                 self._cb(result, None, 0.0)
 

--- a/tests/test_synthesize_worker.py
+++ b/tests/test_synthesize_worker.py
@@ -89,3 +89,14 @@ def test_synthesize_worker_prints_elapsed_time(capfd, tmp_path):
     worker.run()
     captured = capfd.readouterr().out
     assert 'Generated in' in captured and 'seconds' in captured
+
+
+def dummy_transcriber(text, **kwargs):
+    return text.upper()
+
+
+def test_synthesize_worker_handles_none_output(capfd):
+    worker = SynthesizeWorker(dummy_transcriber, 'hi', None, {})
+    worker.run()
+    captured = capfd.readouterr().out
+    assert 'Generated in' in captured and 'seconds' in captured


### PR DESCRIPTION
## Summary
- allow `SynthesizeWorker` output to be optional
- invoke backend without output path when using a transcriber
- adjust unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f9260d7c8329873215263b997e8f