### PR TITLE
Persist backend install status

### DIFF
--- a/gui_pyside6/planning.md
+++ b/gui_pyside6/planning.md
@@ -36,4 +36,6 @@ This document tracks the initial tasks for building the PySide6 Hybrid TTS appli
 - Ensure pip is available when installing optional backends by invoking
   `python -m ensurepip` before `pip install`. Also fix backend import errors by
   explicitly importing `importlib.util`.
+- Persist optional backend install status in `~/.hybrid_tts/install.log` and load
+  it on startup so the UI remembers previously installed backends.
 

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -952,7 +952,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def update_install_status(self):
         backend = self.backend_combo.currentText()
-        if is_backend_installed(backend):
+        from ..backend import backend_was_installed
+        if backend_was_installed(backend):
             self.install_button.setEnabled(False)
             self.install_button.setText("Backend Installed")
         else:


### PR DESCRIPTION
## Summary
- record installs in `~/.hybrid_tts/install.log`
- read the log at startup to remember which backends were installed
- use this persisted info in the UI
- document the new behaviour
- test install logging and persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843099c44ec8329968566ae9b81404d