### PR TITLE
Update waveform selection handling

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -684,6 +684,9 @@ class MainWindow(QtWidgets.QMainWindow):
         path = Path(item.text())
         if path.exists():
             self.last_output = path
+            if path.exists():
+                self.waveform.set_audio_file(path)
+                self.player.setSource(QUrl.fromLocalFile(str(path)))
             self.on_play_output()
 
 
@@ -713,8 +716,14 @@ class MainWindow(QtWidgets.QMainWindow):
                         first = paths[0]
                         output_desc = first.parent
                         self.last_output = first
+                        # insert newest paths at the top and load each as it becomes selected
                         for p in reversed(paths):
+                            self.last_output = p
                             self.history_list.insertItem(0, str(p))
+                            if p.exists():
+                                self.waveform.set_audio_file(p)
+                                self.player.setSource(QUrl.fromLocalFile(str(p)))
+                        self.last_output = first
                     else:
                         self.last_output = None
                 elif isinstance(output, (str, Path)):

--- a/tests/test_history_list.py
+++ b/tests/test_history_list.py
@@ -227,12 +227,20 @@ def test_list_of_paths_handled(tmp_path):
     window = main_window.MainWindow()
     window.autoplay_check = types.SimpleNamespace(isChecked=lambda: False)
 
+    # track waveform updates
+    calls = []
+    def fake_set_audio_file(self, path):
+        calls.append(Path(path))
+    window.waveform.set_audio_file = types.MethodType(fake_set_audio_file, window.waveform)
+
     p1 = tmp_path / 'seg1.wav'
     p2 = tmp_path / 'seg2.wav'
     p1.write_text('a')
     p2.write_text('b')
 
     window.on_synthesize_finished([p1, p2], None, 0.0)
+
+    assert calls == [p2, p1, p1]
 
     assert window.last_output == p1
     assert window.history_list.items[0] == str(p1)


### PR DESCRIPTION
## Summary
- ensure waveform widget updates for each output path
- load waveform when an item is played from history
- test that waveform updates for multiple output files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430baeb1508329982ddafd307dff9e