### PR TITLE
Update whisper backend deps

### DIFF
--- a/gui_pyside6/SALVAGE_LOG.md
+++ b/gui_pyside6/SALVAGE_LOG.md
@@ -47,3 +47,4 @@ This file tracks files copied or cleaned during the migration to the PySide6 GUI
   also checks `VIRTUAL_ENV` and `CONDA_PREFIX` so Conda environments are handled
   correctly.
 - Replaced `extension_*` backend requirements with official pip packages and added a minimal `mms_languages.txt` file.
+- Added `transformers` as an additional dependency for the `whisper` backend.

--- a/gui_pyside6/backend/backend_requirements.json
+++ b/gui_pyside6/backend/backend_requirements.json
@@ -36,6 +36,7 @@
     "nltk"
   ],
   "whisper": [
-    "openai-whisper"
+    "openai-whisper",
+    "transformers"
   ]
 }

--- a/gui_pyside6/notes/backend_categories.md
+++ b/gui_pyside6/notes/backend_categories.md
@@ -20,6 +20,6 @@ These backends operate on audio files instead of text. The UI displays a file pi
 
 - **demucs** – splits audio into stems
 - **vocos** – reconstructs audio using a neural codec
-- **whisper** – transcribes speech to text
+- **whisper** – transcribes speech to text (requires `openai-whisper` and `transformers`)
 
 Backends marked as experimental either failed to install or had unresolved issues during testing.


### PR DESCRIPTION
## Summary
- add `transformers` to whisper backend requirements
- document whisper dependency in SALVAGE_LOG and backend_categories

## Testing
- `pytest -q` *(fails: Client.__init__() unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684318bc2d8c83299c74781d8507d847