### PR TITLE
Add Whisper timestamp option

### DIFF
--- a/gui_pyside6/backend/whisper_backend.py
+++ b/gui_pyside6/backend/whisper_backend.py
@@ -7,6 +7,7 @@ def transcribe_to_text(
     audio_path: Path,
     *,
     model_name: str = "openai/whisper-large-v3",
+    return_timestamps: bool | None = None,
 ) -> str:
     """Transcribe speech from ``audio_path`` using a Whisper model.
 
@@ -16,6 +17,10 @@ def transcribe_to_text(
         Path to an audio file supported by ``transformers``.
     model_name:
         HuggingFace model identifier.
+    return_timestamps:
+        If ``None``, automatically enable timestamps when the input audio
+        duration is greater than 30 seconds. Otherwise, explicitly pass
+        ``True`` or ``False`` to control timestamp generation.
     Returns
     -------
     str
@@ -24,9 +29,28 @@ def transcribe_to_text(
     from transformers import pipeline
     import torch
 
+    if return_timestamps is None:
+        duration = 0.0
+        try:
+            import soundfile as sf
+
+            info = sf.info(str(audio_path))
+            duration = info.frames / float(info.samplerate)
+        except Exception:
+            try:
+                import torchaudio
+
+                info = torchaudio.info(str(audio_path))
+                duration = info.num_frames / float(info.sample_rate)
+            except Exception:
+                duration = 0.0
+        return_timestamps = duration > 30.0
+
     device = 0 if torch.cuda.is_available() else -1
-    pipe = pipeline("automatic-speech-recognition", model=model_name, device=device)
-    result = pipe(str(audio_path))
+    pipe = pipeline(
+        "automatic-speech-recognition", model=model_name, device=device
+    )
+    result = pipe(str(audio_path), return_timestamps=return_timestamps)
     if isinstance(result, dict):
         return result.get("text", "")
     return str(result)

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -505,6 +505,8 @@ class MainWindow(QtWidgets.QMainWindow):
         elif hasattr(self.whisper_model_combo, "setCurrentText"):
             self.whisper_model_combo.setCurrentText("small")
         whisper_form.addRow("Model", self.whisper_model_combo)
+        self.whisper_ts_checkbox = QtWidgets.QCheckBox("Force timestamps")
+        whisper_form.addRow("Return timestamps", self.whisper_ts_checkbox)
         self.whisper_opts = QtWidgets.QGroupBox("Whisper Options")
         self.whisper_opts.setLayout(whisper_form)
         self.whisper_opts.setVisible(False)
@@ -653,6 +655,8 @@ class MainWindow(QtWidgets.QMainWindow):
             kwargs["seed"] = seed
         if backend == "whisper":
             kwargs["model_name"] = self.whisper_model_combo.currentText()
+            if hasattr(self, "whisper_ts_checkbox") and self.whisper_ts_checkbox.isChecked():
+                kwargs["return_timestamps"] = True
 
         print(f"[INFO] Synthesizing with {backend}...")
         self.worker = SynthesizeWorker(func, text, output, kwargs)


### PR DESCRIPTION
## Summary
- whisper: add automatic timestamp detection and optional parameter
- add checkbox in Whisper Options to manually force timestamps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68436096d5d08329884b742f1683debc