### PR TITLE
Update default Whisper model

### DIFF
--- a/gui_pyside6/backend/api_server.py
+++ b/gui_pyside6/backend/api_server.py
@@ -35,7 +35,7 @@ class SeparationRequest(BaseModel):
 class TranscriptionRequest(BaseModel):
     audio: str
     backend: str = "whisper"
-    model: Optional[str] = None
+    model: Optional[str] = "openai/whisper-small"
 
 
 @app.post("/synthesize")
@@ -62,7 +62,7 @@ def separate(req: SeparationRequest):
 def transcribe(req: TranscriptionRequest):
     if req.backend not in TRANSCRIBERS:
         raise HTTPException(status_code=400, detail="Unsupported backend")
-    text = TRANSCRIBERS[req.backend](Path(req.audio), model_name=req.model or "openai/whisper-large-v3")
+    text = TRANSCRIBERS[req.backend](Path(req.audio), model_name=req.model or "openai/whisper-small")
     return {"text": text}
 
 

--- a/gui_pyside6/backend/whisper_backend.py
+++ b/gui_pyside6/backend/whisper_backend.py
@@ -6,7 +6,7 @@ from pathlib import Path
 def transcribe_to_text(
     audio_path: Path,
     *,
-    model_name: str = "openai/whisper-large-v3",
+    model_name: str = "openai/whisper-small",
     return_timestamps: bool | None = None,
 ) -> str:
     """Transcribe speech from ``audio_path`` using a Whisper model.


### PR DESCRIPTION
## Summary
- default `whisper_backend` to use `openai/whisper-small`
- make API transcription use `openai/whisper-small` when no model is specified

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843623a8e1883298530cf2c31c2ff81