### PR TITLE
Add word wrap to status label and truncate errors

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -236,6 +236,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Status label created early so signal handlers can reference it
         self.status = QtWidgets.QLabel()
+        if hasattr(self.status, "setWordWrap"):
+            self.status.setWordWrap(True)
 
         params_group = QtWidgets.QGroupBox("Parameters")
         params_layout = QtWidgets.QVBoxLayout(params_group)
@@ -722,8 +724,11 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def on_synthesize_finished(self, output: object, error: object, elapsed: float):
         if error:
+            msg = str(error)
+            if len(msg) > 200:
+                msg = msg[:200] + "..."
             if hasattr(self.status, "setText"):
-                self.status.setText(f"Error: {error}")
+                self.status.setText(f"Error: {msg}")
             print(f"[ERROR] {error}")
         else:
             self.transcript_view.setVisible(False)


### PR DESCRIPTION
## Summary
- enable word wrap on the status label in MainWindow
- truncate error messages in `on_synthesize_finished`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684364349aa88329b611d7b861645cad