### PR TITLE
Fix transcript visibility after transcriptions

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -736,6 +736,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 transcript = output
                 self.transcript_view.setPlainText(transcript)
                 self.transcript_view.setVisible(True)
+                # ensure the group box is shown when text output is returned
+                self.transcript_group.setVisible(True)
                 if hasattr(self.status, "setText"):
                     self.status.setText("Transcription complete")
                 summary = transcript[:30].replace("\n", " ")


### PR DESCRIPTION
## Summary
- ensure transcript output group is shown whenever text is returned from a backend
- keep history list entry short

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843657096e08329a4c476b3f442026f