### PR TITLE
Fix transcript area visibility on backend change

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -967,6 +967,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.chatterbox_opts.setVisible(backend == "chatterbox")
         self.whisper_opts.setVisible(backend == "whisper")
+        # hide transcripts when switching away from Whisper;
+        # they will be shown again when a transcription completes
+        self.transcript_group.setVisible(backend == "whisper")
         self.update_synthesize_enabled()
         self._last_backend = backend
 


### PR DESCRIPTION
## Summary
- keep transcript section hidden unless Whisper is selected
- add comment for transcript visibility logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436d97c2808329a7aa987b90c745e1