### PR TITLE
Fix backend install detection

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -1036,6 +1036,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 )
                 if val is not None:
                     text = str(val)
+            if not text.strip() and hasattr(self.text_edit, "_stored_text"):
+                text = str(getattr(self.text_edit, "_stored_text", ""))
             text_present = bool(text.strip())
         backend_ready = is_backend_installed(backend)
         busy = getattr(self, "_synth_busy", False)


### PR DESCRIPTION
## Summary
- improve package detection to fall back on module availability
- add helper `_dist_or_module_available`
- check stored text when enabling Synthesize button so typed text is detected

## Testing
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68436f89a164832981b69090fb38e2a6