### PR TITLE
Remove extension_kokoro dependency

### DIFF
--- a/gui_pyside6/backend/kokoro_backend.py
+++ b/gui_pyside6/backend/kokoro_backend.py
@@ -84,32 +84,6 @@ def synthesize_to_file(
 
 def list_voices() -> list[tuple[str, str]]:
     """Return available Kokoro voice display names and identifiers."""
-    try:
-        from extension_kokoro import CHOICES as choices_mod
-        print("[INFO] Loaded voice list from extension_kokoro.CHOICES")
-        return list(getattr(choices_mod, "CHOICES", {}).items())
-    except Exception as e:
-        print(f"[INFO] extension_kokoro.CHOICES not available: {e}")
-
-    try:
-        import importlib.util
-        from pathlib import Path
-        spec = importlib.util.find_spec("extension_kokoro")
-        if spec and spec.origin:
-            choices_path = Path(spec.origin).parent / "CHOICES.py"
-            if choices_path.exists():
-                print(f"[INFO] Loading voices from {choices_path}")
-                namespace: dict[str, object] = {}
-                with choices_path.open("r", encoding="utf-8") as f:
-                    code = f.read()
-                exec(code, namespace)
-                choices = namespace.get("CHOICES", {})
-                if isinstance(choices, dict):
-                    return list(choices.items())
-            else:
-                print(f"[INFO] No CHOICES.py at {choices_path}")
-    except Exception as e:
-        print(f"[WARN] Failed to load voices from CHOICES.py: {e}")
 
     dirs_to_check: list[Path] = []
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -30,13 +30,6 @@ async def dummy_list_voices():
 edge_dummy.list_voices = dummy_list_voices
 sys.modules.setdefault("edge_tts", edge_dummy)
 
-# Dummy Kokoro module for listing voices
-kokoro_mod = types.ModuleType("extension_kokoro")
-kokoro_choices = types.ModuleType("extension_kokoro.CHOICES")
-kokoro_choices.CHOICES = {"Heart": "af_heart"}
-sys.modules.setdefault("extension_kokoro", kokoro_mod)
-sys.modules.setdefault("extension_kokoro.CHOICES", kokoro_choices)
-
 # Dummy Chatterbox module
 chatter_mod = types.ModuleType("chatterbox")
 class DummyChatterboxTTS:
@@ -82,11 +75,12 @@ def test_kokoro_backend_available():
     assert "kokoro" in available_backends()
 
 
-def test_get_kokoro_voices_returns_list():
+def test_get_kokoro_voices_returns_list(tmp_path, monkeypatch):
+    monkeypatch.setenv("KOKORO_VOICE_DIR", str(tmp_path))
+    (tmp_path / "demo.pt").write_text("x")
     from gui_pyside6.backend import get_kokoro_voices
     voices = get_kokoro_voices()
-    assert isinstance(voices, list)
-    assert voices and isinstance(voices[0], tuple) and len(voices[0]) == 2
+    assert voices == [("demo", "demo")]
 
 
 def test_chatterbox_backend_available():
@@ -123,7 +117,6 @@ def test_whisper_backend_available():
 
 
 def test_kokoro_voice_dir_env(tmp_path, monkeypatch):
-    monkeypatch.delitem(sys.modules, "extension_kokoro.CHOICES", raising=False)
     monkeypatch.setenv("KOKORO_VOICE_DIR", str(tmp_path))
     (tmp_path / "custom.pt").write_text("x")
     from gui_pyside6.backend import get_kokoro_voices
@@ -132,7 +125,6 @@ def test_kokoro_voice_dir_env(tmp_path, monkeypatch):
 
 
 def test_kokoro_voice_dir_missing(tmp_path, monkeypatch):
-    monkeypatch.delitem(sys.modules, "extension_kokoro.CHOICES", raising=False)
     monkeypatch.setenv("KOKORO_VOICE_DIR", str(tmp_path))
     from gui_pyside6.backend import get_kokoro_voices
     voices = get_kokoro_voices()


### PR DESCRIPTION
## Summary
- streamline kokoro_backend.list_voices to only search voice directories
- update backend tests to use `KOKORO_VOICE_DIR`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684404e10df08329841ee11bc6d41d3f