### PR TITLE
Fix synth button enable timing

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -1058,7 +1058,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def on_text_changed(self):
         print("[DEBUG] textChanged emitted", file=sys.__stdout__)
-        self.update_synthesize_enabled()
+        QtCore.QTimer.singleShot(0, self.update_synthesize_enabled)
 
     def on_preferences(self):
         dlg = PreferencesDialog(self.prefs, self)


### PR DESCRIPTION
## Summary
- delay enabling the synthesize button until after the text field update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68440e84dc0483298c816b772dd3f1cd