### PR TITLE
Fix synth button enabling

### DIFF
--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -457,9 +457,9 @@ class MainWindow(QtWidgets.QMainWindow):
         player_layout.addWidget(self.autoplay_check)
 
         buttons_row = QtWidgets.QHBoxLayout()
-        self.button = QtWidgets.QPushButton("Synthesize")
-        safe_connect(self.button.clicked, self.on_synthesize)
-        buttons_row.addWidget(self.button)
+        self.synth_button = QtWidgets.QPushButton("Synthesize")
+        safe_connect(self.synth_button.clicked, self.on_synthesize)
+        buttons_row.addWidget(self.synth_button)
 
         self.open_button = QtWidgets.QPushButton("Open Output Folder")
         safe_connect(self.open_button.clicked, self.on_open_output)
@@ -875,8 +875,8 @@ class MainWindow(QtWidgets.QMainWindow):
     def on_backend_changed(self, backend: str):
         prev_backend = getattr(self, "_last_backend", None)
         prev_features = BACKEND_FEATURES.get(prev_backend, set()) if prev_backend else set()
-        if hasattr(self.button, "setText"):
-            self.button.setText("Transcribe" if backend in TRANSCRIBERS else "Synthesize")
+        if hasattr(self.synth_button, "setText"):
+            self.synth_button.setText("Transcribe" if backend in TRANSCRIBERS else "Synthesize")
         if hasattr(self.status, "setText"):
             self.status.setText(BACKEND_INFO.get(backend, ""))
         self.update_install_status()
@@ -1054,7 +1054,7 @@ class MainWindow(QtWidgets.QMainWindow):
             f"[DEBUG] synth_btn state text_present={text_present}, busy={busy}",
             file=sys.__stdout__,
         )
-        self.button.setEnabled(text_present and not busy)
+        self.synth_button.setEnabled(text_present and not busy)
 
     def on_text_changed(self):
         print("[DEBUG] textChanged emitted", file=sys.__stdout__)


### PR DESCRIPTION
## Summary
- fix `synth_button` hookup so synthesize button enables correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx, matplotlib, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684412b52d4c8329b9ac38bea8b9d596