### PR TITLE
Add log file opener to preferences

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -60,6 +60,7 @@ Open **Edit → Preferences** to configure the application.
 - **Auto play after synthesis** – automatically play generated audio.
 - **Output directory** – folder where synthesized files are saved. Defaults to `outputs/`.
 - **Uninstall Backends** – remove optional TTS backends you previously installed.
+- **Open Log File** – open the folder containing application logs.
 
 Custom translation files can be placed in `~/.hybrid_tts/translations` to
 augment the UI language list.

--- a/gui_pyside6/ui/preferences.py
+++ b/gui_pyside6/ui/preferences.py
@@ -5,6 +5,7 @@ from PySide6 import QtWidgets, QtCore
 from ..backend import available_backends, is_backend_installed, uninstall_backend
 from ..utils.languages import get_available_languages
 from ..utils.preferences import load_preferences
+from ..utils.open_folder import open_log_dir
 
 
 class PreferencesDialog(QtWidgets.QDialog):
@@ -61,6 +62,9 @@ class PreferencesDialog(QtWidgets.QDialog):
         self.uninstall_btn = QtWidgets.QPushButton("Uninstall Selected")
         self.uninstall_btn.clicked.connect(self.on_uninstall)
         btn_row.addWidget(self.uninstall_btn)
+        log_btn = QtWidgets.QPushButton("Open Log File")
+        log_btn.clicked.connect(self.on_open_log)
+        btn_row.addWidget(log_btn)
         close_btn = QtWidgets.QPushButton("Close")
         close_btn.clicked.connect(self.accept)
         btn_row.addWidget(close_btn)
@@ -85,6 +89,9 @@ class PreferencesDialog(QtWidgets.QDialog):
             backend = item.data(QtCore.Qt.UserRole)
             uninstall_backend(backend)
         self.refresh_backends()
+
+    def on_open_log(self) -> None:
+        open_log_dir()
 
     def get_preferences(self) -> dict:
         return {

--- a/gui_pyside6/utils/open_folder.py
+++ b/gui_pyside6/utils/open_folder.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+from pathlib import Path
 
 if sys.platform == "darwin":
 
@@ -15,6 +16,13 @@ elif sys.platform == "win32":
 
     def open_folder(folder_path: str):
         subprocess.Popen(["explorer", folder_path])
+
+
+LOG_DIR = Path.home() / ".hybrid_tts"
+
+def open_log_dir():
+    """Open the directory containing the application log file."""
+    open_folder(str(LOG_DIR))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `open_log_dir` helper
- add `Open Log File` button in Preferences dialog
- document the new option in README

## Testing
- `pip install -r tests/requirements-dev.in`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443053b40c83299726536a3593380a