### PR TITLE
Add Process button for tool backends

### DIFF
--- a/tests/test_history_list.py
+++ b/tests/test_history_list.py
@@ -344,14 +344,17 @@ def test_button_visibility_updates_by_backend(tmp_path):
 
     window = main_window.MainWindow()
     assert window.synth_button.isVisible()
+    assert not window.process_button.isVisible()
     assert not window.transcribe_button.isVisible()
 
     window.on_backend_changed('whisper')
     assert not window.synth_button.isVisible()
+    assert window.process_button.isVisible()
     assert window.transcribe_button.isVisible()
 
     window.on_backend_changed('pyttsx3')
     assert window.synth_button.isVisible()
+    assert not window.process_button.isVisible()
     assert not window.transcribe_button.isVisible()
     for m in list(sys.modules):
         if m.startswith('PySide6'):


### PR DESCRIPTION
## Summary
- add `process_button` widget in the main window
- expose a new `on_process` handler wired through `_run_backend`
- toggle visibility and enable state for the new button based on selected backend
- update existing visibility checks in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443d617c8c832994162f6f42afdf8d