### PR TITLE
Fix backend button logic

### DIFF
--- a/gui_pyside6/backend/__init__.py
+++ b/gui_pyside6/backend/__init__.py
@@ -87,7 +87,10 @@ TTS_BACKENDS = [
     "chatterbox",
 ]
 
-TOOL_BACKENDS = ["demucs", "vocos", "whisper"]
+# Tool backends operate on audio files rather than generating speech from text.
+# Whisper is handled separately as a transcriber, so it should not be included
+# in this list.
+TOOL_BACKENDS = ["demucs", "vocos"]
 
 EXPERIMENTAL_BACKENDS = ["bark", "tortoise"]
 

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -1122,6 +1122,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.update_synthesize_enabled()
 
     def update_install_status(self):
+        if self.backend_combo is None:
+            return
         backend = self.backend_combo.currentText()
         from ..backend import backend_was_installed
         if backend_was_installed(backend):
@@ -1133,6 +1135,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.update_synthesize_enabled()
 
     def update_synthesize_enabled(self):
+        if self.backend_combo is None:
+            return
         backend = self.backend_combo.currentText()
         features = BACKEND_FEATURES.get(backend, set())
         file_required = "file" in features

--- a/tests/test_history_list.py
+++ b/tests/test_history_list.py
@@ -349,7 +349,8 @@ def test_button_visibility_updates_by_backend(tmp_path):
 
     window.on_backend_changed('whisper')
     assert not window.synth_button.isVisible()
-    assert window.process_button.isVisible()
+    # Whisper is a transcriber, not an audio tool
+    assert not window.process_button.isVisible()
     assert window.transcribe_button.isVisible()
 
     window.on_backend_changed('pyttsx3')


### PR DESCRIPTION
## Summary
- don't classify `whisper` as an audio tool
- guard backend combo usage when the settings tab is open
- update button visibility test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684444c6644483299c7a112332223504