### PR TITLE
Add always-enable flag for GUI controls

### DIFF
--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -49,6 +49,9 @@ See also:
 - Backends should be implemented under `/gui_pyside6/backend/`.
 - Optional backends listed in `backend/backend_requirements.json`.
 - Backend and UI-related changes should be documented in the appropriate `.md` files (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
+- Set `HYBRID_TTS_ALWAYS_ENABLE=1` in the environment to force the **Synthesize**,
+  **Transcribe**, and **Process** buttons to stay enabled regardless of input
+  state.
 
 ## Documentation Sections
 

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -1174,6 +1174,11 @@ class MainWindow(QtWidgets.QMainWindow):
     def update_synthesize_enabled(self):
         if self.backend_combo is None:
             return
+        if os.environ.get("HYBRID_TTS_ALWAYS_ENABLE") == "1":
+            self.synth_button.setEnabled(True)
+            self.transcribe_button.setEnabled(True)
+            self.process_button.setEnabled(True)
+            return
         backend = self.backend_combo.currentText()
         features = BACKEND_FEATURES.get(backend, set())
         file_required = "file" in features


### PR DESCRIPTION
## Summary
- allow forcing main UI buttons enabled via `HYBRID_TTS_ALWAYS_ENABLE=1`
- document the env variable in the developer notes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444c6431fc83299390a4b810ca11bc