### PR TITLE
Add FastAPI to test requirements

### DIFF
--- a/tests/requirements-dev.in
+++ b/tests/requirements-dev.in
@@ -1,4 +1,7 @@
+# Test requirements for Hybrid PySide6 app
+# fastapi is needed for API server tests
 pytest
+fastapi
 httpx==0.24.1
 matplotlib
 numpy


### PR DESCRIPTION
## Summary
- update test requirements to include FastAPI for API tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68445b97772883299d6c148800d046fd