### PR TITLE
Add logging and test for textChanged handling

### DIFF
--- a/gui_pyside6/docs/index.md
+++ b/gui_pyside6/docs/index.md
@@ -86,7 +86,9 @@ On Windows, set the variable and then run the command:
   ```
 
 Logs are written to `~/.hybrid_tts/app.log` and can clarify problems with UI
-state, such as the **Synthesize** button remaining disabled.
+state, such as the **Synthesize** button remaining disabled. When debugging GUI
+state issues, enable this logging to see events like `textChanged` and the
+values captured by `_record_text`.
 
 ## Notes and Investigations
 

--- a/gui_pyside6/ui/main_window.py
+++ b/gui_pyside6/ui/main_window.py
@@ -386,9 +386,9 @@ class MainWindow(QtWidgets.QMainWindow):
             return val
 
         def _record_text():
-            val = _orig_to_plain() if callable(_orig_to_plain) else None
-            if val is not None:
-                self.text_edit._stored_text = str(val)
+            val = self.text_edit.document().toPlainText()
+            logger.debug("_record_text captured text: %r", val)
+            self.text_edit._stored_text = str(val)
 
         self.text_edit.setPlainText = _set_plain
         self.text_edit.toPlainText = _to_plain

--- a/tests/test_record_text_signal.py
+++ b/tests/test_record_text_signal.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from tests.test_history_list import _setup_pyside6_stubs, qtcore_mod, qtwidgets_mod, DummySignal, DummyPlainTextEdit
+from gui_pyside6.utils import preferences as prefs
+
+
+class DummyTimer:
+    @staticmethod
+    def singleShot(ms, func):
+        func()
+
+
+def _setup_with_signal():
+    # Enable capturing of connected slots
+    def connect(self, slot):
+        self._slots = getattr(self, "_slots", [])
+        self._slots.append(slot)
+
+    def emit(self, *args, **kwargs):
+        for s in getattr(self, "_slots", []):
+            s(*args, **kwargs)
+
+    DummySignal.connect = connect
+    DummySignal.emit = emit
+
+    # Provide document() API used by _record_text
+    DummyPlainTextEdit.document = lambda self: types.SimpleNamespace(toPlainText=lambda: self.text)
+
+    qtcore_mod.QTimer = DummyTimer
+    return _setup_pyside6_stubs()
+
+
+def test_text_changed_signal_updates_stored_and_enables(tmp_path):
+    saved = _setup_with_signal()
+    prefs.PREF_FILE = tmp_path / "prefs.json"
+    prefs.save_preferences({})
+
+    import importlib
+    import gui_pyside6.ui.main_window as main_window
+    importlib.reload(main_window)
+
+    main_window.is_backend_installed = lambda name: True
+
+    window = main_window.MainWindow()
+    window.synth_button._enabled = False
+    window.synth_button.setEnabled = lambda val: setattr(window.synth_button, "_enabled", val)
+    window.synth_button.isEnabled = lambda: getattr(window.synth_button, "_enabled", False)
+
+    window.text_edit.text = "hello"
+    window.text_edit.textChanged.emit()
+
+    assert window.text_edit._stored_text == "hello"
+    assert window.synth_button.isEnabled() is True
+
+    for m in list(sys.modules):
+        if m.startswith("PySide6"):
+            sys.modules.pop(m)
+    sys.modules.update(saved)


### PR DESCRIPTION
## Summary
- log captured text in `_record_text`
- document debug logging and mention GUI state debugging
- test that textChanged updates stored text and enables synth button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684470a4d154832983be1089b778a54b