### PR TITLE
Switch Kokoro backend to official package

### DIFF
--- a/gui_pyside6/backend/backend_requirements.json
+++ b/gui_pyside6/backend/backend_requirements.json
@@ -29,7 +29,7 @@
     "vocos"
   ],
   "kokoro": [
-    "kokoro-fastapi"
+    "kokoro"
   ],
   "chatterbox": [
     "chatterbox-tts",

--- a/gui_pyside6/backend/metadata/kokoro.toml
+++ b/gui_pyside6/backend/metadata/kokoro.toml
@@ -1,3 +1,3 @@
-package = "kokoro-fastapi"
+package = "kokoro"
 repo_url = "https://github.com/hexgrad/kokoro"
 description = "Kokoro TTS with voice presets."

--- a/gui_pyside6/investigation.md
+++ b/gui_pyside6/investigation.md
@@ -56,3 +56,10 @@ Tests cover text edits and audio file loads to ensure
 found where the **Synthesize** button stays disabled beyond earlier backend
 exceptions interrupting the finish callback.
 
+### Follow-up 8
+
+The Kokoro project officially released the `kokoro` distribution on PyPI.
+Previous versions required using the temporary `kokoro-fastapi` package.
+Our backend metadata and requirements now depend on `kokoro` to match the
+published package name.  Tests and installation helpers were updated accordingly.
+

--- a/tests/test_lazy_install.py
+++ b/tests/test_lazy_install.py
@@ -48,9 +48,9 @@ def test_is_backend_installed_false():
         assert not is_backend_installed('pyttsx3')
 
 
-def test_kokoro_fastapi_is_recognized():
+def test_kokoro_distribution_is_recognized():
     def fake_distribution(name):
-        if name == 'kokoro-fastapi':
+        if name == 'kokoro':
             return object()
         raise importlib.metadata.PackageNotFoundError
 

--- a/tests/test_missing_backend_packages.py
+++ b/tests/test_missing_backend_packages.py
@@ -36,11 +36,11 @@ def test_case_insensitive_module_name():
     assert missing == []
 
 
-def test_kokoro_fastapi_counts_as_installed():
-    """``kokoro-fastapi`` should satisfy the ``kokoro`` backend."""
+def test_kokoro_distribution_counts_as_installed():
+    """``kokoro`` distribution should satisfy the ``kokoro`` backend."""
 
     def fake_distribution(name):
-        if name == 'kokoro-fastapi':
+        if name == 'kokoro':
             class D: ...
             return D()
         raise importlib.metadata.PackageNotFoundError


### PR DESCRIPTION
## Summary
- point Kokoro backend requirements at the `kokoro` distribution
- update Kokoro metadata to reference the new package
- adjust tests to look for the `kokoro` package
- document the change in investigation notes

## Testing
- `pip install -r tests/requirements-dev.in`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844798574a88329b9fc0e983edfbb26