### PR TITLE
Add Kokoro-FastAPI install notes

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -33,6 +33,13 @@ for the first time the file downloads from Hugging Face into the cache directory
 (`~/.cache/huggingface/hub` by default). Set `KOKORO_VOICE_DIR` to override the
 location where voice `.pt` files are loaded from.
 
+The optional **Kokoro-FastAPI** server isn't on PyPI. Install it directly from
+GitHub if you want to run the standalone service:
+
+```bash
+pip install "kokoro-fastapi @ git+https://github.com/remsky/Kokoro-FastAPI.git"
+```
+
 Backend packages are defined in `backend/backend_requirements.json`. Installation first checks if the app is running inside a virtual environment; if so, packages install there. Detection now also considers `VIRTUAL_ENV` or `CONDA_PREFIX` environment variables so Conda and other managers work. If no environment is active, packages install into a per-user environment at `~/.hybrid_tts/venv` (`C:\Users\USERNAME\.hybrid_tts\venv` on Windows).
 Metadata files under `backend/metadata/` record the primary package name and repository URL for each backend.
 

--- a/gui_pyside6/backend/backend_requirements.json
+++ b/gui_pyside6/backend/backend_requirements.json
@@ -31,6 +31,9 @@
   "kokoro": [
     "kokoro"
   ],
+  "kokoro_fastapi": [
+    "kokoro-fastapi @ git+https://github.com/remsky/Kokoro-FastAPI.git"
+  ],
   "chatterbox": [
     "chatterbox-tts",
     "nltk"

--- a/gui_pyside6/backend/metadata/kokoro_fastapi.toml
+++ b/gui_pyside6/backend/metadata/kokoro_fastapi.toml
@@ -1,0 +1,3 @@
+package = "kokoro-fastapi"
+repo_url = "https://github.com/remsky/Kokoro-FastAPI"
+description = "FastAPI service wrapping Kokoro TTS."

--- a/gui_pyside6/planning.md
+++ b/gui_pyside6/planning.md
@@ -45,6 +45,10 @@ This document tracks the initial tasks for building the PySide6 Hybrid TTS appli
   can run even when detection is unreliable.
 - Verify Kokoro backend installation with the new `kokoro` package.
 
+- `Kokoro-FastAPI` is not published on PyPI. Install it from Git when you
+  need the standalone server:
+  `pip install "kokoro-fastapi @ git+https://github.com/remsky/Kokoro-FastAPI.git"`
+
 - Refactor `on_synthesize` into helper methods for easier maintenance.
 - Investigate missing Kokoro voice packs with `KPipeline` and document findings
   in `investigation.md`.


### PR DESCRIPTION
## Summary
- mention that Kokoro-FastAPI must be installed from GitHub
- track the step in planning
- list `kokoro_fastapi` backend with VCS URL
- add metadata for Kokoro FastAPI

## Testing
- `pip install -r tests/requirements-dev.in`
- `pip install huggingface_hub`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448380a6b48329889a4f6b859800a9