### PR TITLE
Update README launcher explanation

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -14,8 +14,9 @@ All Hybrid app code, scripts and dependencies stay inside `/gui_pyside6/`. Do no
 
 1. Install **Python 3.11** and the [`uv`](https://github.com/astral-sh/uv) package.
 2. Run `run_pyside.sh` (Linux/macOS) or `run_pyside.bat` (Windows) from this directory.
-   The script creates a virtual environment, installs `requirements.uv.toml`,
-   optionally installs PyTorch, and launches the GUI from the repository root.
+   The script creates a virtual environment, compiles `requirements.in` into
+   `requirements.lock.txt`, installs packages from that lock file, optionally
+   installs PyTorch, and launches the GUI from the repository root.
 3. You can also start the GUI manually (from the repository root) with:
 
    ```bash


### PR DESCRIPTION
## Summary
- fix docs: the launcher compiles `requirements.in` to `requirements.lock.txt` and installs from the lock file

## Testing
- `pip install -r tests/requirements-dev.in`
- `pip install huggingface-hub`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448e74c8648329bfc87b2d561c910b