### PR TITLE
Add lock file update instructions

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -129,3 +129,11 @@ Tests cover backend installation helpers and the API server.
 - `requirements.uv.toml` lists only base packages; optional backends are listed in `backend/backend_requirements.json`.
 - You may copy utility code from other folders but do **not** modify the legacy WebUI or React UI projects.
 
+## Updating Dependencies
+
+1. Edit `requirements.in` to add or update base packages.
+2. Run `uv pip compile requirements.in -o requirements.lock.txt` to regenerate the lock file.
+3. Commit **both** `requirements.in` and `requirements.lock.txt` so the lock file stays in sync.
+
+`install_torch.py` installs the appropriate PyTorch build separately after the lock file sync.
+


### PR DESCRIPTION
## Summary
- document how to regenerate the lock file and commit it
- mention that install_torch.py installs PyTorch separately

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6844905f5ac08329b3d7c480f09b2728