### PR TITLE
Add Briefcase packaging guide

### DIFF
--- a/gui_pyside6/README.md
+++ b/gui_pyside6/README.md
@@ -138,3 +138,7 @@ Tests cover backend installation helpers and the API server.
 
 `install_torch.py` installs the appropriate PyTorch build separately after the lock file sync.
 
+
+## Packaging with Briefcase
+
+See [docs/packaging_briefcase.md](docs/packaging_briefcase.md) for instructions on creating packaged builds with BeeWare Briefcase.

--- a/gui_pyside6/docs/packaging_briefcase.md
+++ b/gui_pyside6/docs/packaging_briefcase.md
@@ -1,0 +1,23 @@
+# Packaging with Briefcase
+
+This project can be packaged into a standalone application using [BeeWare Briefcase](https://briefcase.readthedocs.io/).
+Follow the steps below to create platform specific builds.
+
+1. Install Briefcase:
+   ```bash
+   pip install briefcase
+   ```
+2. Generate the initial project skeleton:
+   ```bash
+   briefcase create
+   ```
+3. Build the application:
+   ```bash
+   briefcase build
+   ```
+4. Create the distributable package:
+   ```bash
+   briefcase package
+   ```
+
+The packaged application should run `install_torch.py` the first time it starts (or include the correct PyTorch wheel in the bundle) so that the appropriate PyTorch build is installed for the user.


### PR DESCRIPTION
## Summary
- document packaging with BeeWare Briefcase
- link the new doc from README

## Testing
- `pip install -r tests/requirements-dev.in`
- `pip install huggingface_hub`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844910ac5d08329aa6e4c61fbb038f1