### PR TITLE
Add uv-aware backend installation

### DIFF
--- a/tests/test_backend_installer.py
+++ b/tests/test_backend_installer.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from gui_pyside6.backend import _install_backend_packages
+
+
+def _capture_calls():
+    calls = []
+    def _run(*a, **k):
+        calls.append(('run', a[0]))
+    def _call(cmd, **k):
+        calls.append(('call', cmd))
+    return calls, _run, _call
+
+
+def test_uv_used_when_available():
+    calls, run_fn, call_fn = _capture_calls()
+    with mock.patch('gui_pyside6.backend._uv_available', return_value=True), \
+         mock.patch('gui_pyside6.backend.install_utils._is_venv_active', return_value=True), \
+         mock.patch('subprocess.run', side_effect=run_fn), \
+         mock.patch('subprocess.check_call', side_effect=call_fn):
+        _install_backend_packages(['foo'], no_deps=True)
+
+    install_cmd = [c[1] for c in calls if c[0] == 'call'][0]
+    assert install_cmd[:3] == ['uv', 'pip', 'install']
+    assert '-p' in install_cmd
+    assert '--no-deps' in install_cmd
+
+
+def test_pip_used_when_uv_missing():
+    calls, run_fn, call_fn = _capture_calls()
+    with mock.patch('gui_pyside6.backend._uv_available', return_value=False), \
+         mock.patch('gui_pyside6.backend.install_utils._is_venv_active', return_value=True), \
+         mock.patch('subprocess.run', side_effect=run_fn), \
+         mock.patch('subprocess.check_call', side_effect=call_fn):
+        _install_backend_packages(['foo'], no_deps=False)
+
+    install_cmd = [c[1] for c in calls if c[0] == 'call'][0]
+    assert install_cmd[:4] == [sys.executable, '-m', 'pip', 'install']
+    assert '--no-deps' not in install_cmd

--- a/tests/test_lazy_install.py
+++ b/tests/test_lazy_install.py
@@ -26,14 +26,14 @@ import importlib.metadata
 
 def test_install_called_when_missing():
     with mock.patch('importlib.metadata.distribution', side_effect=importlib.metadata.PackageNotFoundError):
-        with mock.patch('gui_pyside6.backend.install_package_in_venv') as install:
+        with mock.patch('gui_pyside6.backend._install_backend_packages') as install:
             ensure_backend_installed('pyttsx3')
             install.assert_called_once()
 
 
 def test_install_skipped_when_present():
     with mock.patch('importlib.metadata.distribution', return_value=object()):
-        with mock.patch('gui_pyside6.backend.install_package_in_venv') as install:
+        with mock.patch('gui_pyside6.backend._install_backend_packages') as install:
             ensure_backend_installed('pyttsx3')
             install.assert_not_called()
 
@@ -89,7 +89,7 @@ def test_install_logged_and_persisted(tmp_path):
          mock.patch('gui_pyside6.backend._INSTALL_LOG', log_file), \
          mock.patch('gui_pyside6.backend._get_backend_packages', return_value=['foo==1']), \
          mock.patch('importlib.metadata.distribution', side_effect=importlib.metadata.PackageNotFoundError), \
-         mock.patch('gui_pyside6.backend.install_package_in_venv') as install:
+         mock.patch('gui_pyside6.backend._install_backend_packages') as install:
         from gui_pyside6 import backend
         backend._INSTALLED_BACKENDS.clear()
         ensure_backend_installed('dummy')


### PR DESCRIPTION
## Summary
- install lazy backend packages with `uv pip` when available
- always use `--no-deps` for torch-based backends
- add helper to detect UV
- test uv installer selection
- update lazy install tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844975b0cfc8329a10c8d590ba4d0b3