### PR TITLE
Align option group placement

### DIFF
--- a/gui_pyside6/CONTRIBUTING.md
+++ b/gui_pyside6/CONTRIBUTING.md
@@ -62,6 +62,22 @@ When adding or modifying code in `/gui_pyside6/`, document changes in the approp
 - Maintain a flat, clean backend list.
 - Implement new backends fully within `/gui_pyside6/backend/`.
 
+## UI Layout Guidelines
+
+- All backend-specific option groups must:
+
+    - Be created at window init time (not dynamically later).
+    - Be added consistently to the UI:
+
+        - If simple, add to Parameters area layout.
+        - If complex (e.g. Chatterbox Options), add to main layout *above* History area.
+
+    - Be shown/hidden using `.setVisible()` depending on selected backend and available voices/parameters.
+
+This ensures consistent UI layout and prevents widgets from appearing in unexpected order.
+
+If adding a new backend, please follow this pattern.
+
 ## Workflow for Adding New Backends
 
 1. Implement the backend in `/gui_pyside6/backend/`.

--- a/tests/test_chatterbox_ui.py
+++ b/tests/test_chatterbox_ui.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import importlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from tests.test_on_install_finished import _setup_pyside6_stubs
+from gui_pyside6.utils import preferences as prefs
+
+
+def test_chatterbox_voice_dropdown_hidden(tmp_path):
+    saved = _setup_pyside6_stubs()
+    prefs.PREF_FILE = tmp_path / 'prefs.json'
+    prefs.save_preferences({})
+
+    import gui_pyside6.ui.main_window as main_window
+    importlib.reload(main_window)
+
+    main_window.is_backend_installed = lambda name: True
+    import gui_pyside6.backend as backend_mod
+    backend_mod.get_chatterbox_voices = lambda: []
+
+    window = main_window.MainWindow()
+    window.on_backend_changed('chatterbox')
+
+    assert not getattr(window.voice_combo, 'visible', True)
+
+    for m in list(sys.modules):
+        if m.startswith('PySide6'):
+            sys.modules.pop(m)
+    sys.modules.update(saved)


### PR DESCRIPTION
## Summary
- place Chatterbox options above History in main layout
- add Whisper options to Parameters area
- hide voice dropdown if Chatterbox provides no voices
- document UI layout guidelines
- test Chatterbox voice dropdown visibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ac03c46c83299db63e4429503331